### PR TITLE
ci: run Nanvix Python CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
         description: "CPython release tag to test (e.g., abc1234-nanvix-def5678)"
         required: false
         default: ""
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- add a pull_request trigger for branch main in CI workflow
- keep existing repository_dispatch, workflow_dispatch, and push triggers unchanged

## Why
PRs were not scheduling this workflow because pull_request was not declared in .github/workflows/ci.yml.