### PR TITLE
ci: enable release artifact creation on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     needs: [get-release-info, test]
     if: >-
       ${{ success() &&
-          (github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch') }}
+          (github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' || github.event_name == 'push') }}
     runs-on: ubuntu-latest
     steps:
       - name: Download runtime artifacts from all test jobs


### PR DESCRIPTION
The `release-runtime-artifacts` job's `if` condition only allowed `repository_dispatch` and `workflow_dispatch` events. A merge to `main` triggers a `push` event, which was excluded — causing the release job to be skipped entirely.

This adds `github.event_name == 'push'` to the condition so releases are also created on merges to main.