### PR TITLE
feat(libffi): integrate libffi as static library

### DIFF
--- a/tests/func/test_105_libffi.py
+++ b/tests/func/test_105_libffi.py
@@ -1,0 +1,22 @@
+"""Test: libffi (via ctypes)"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import ctypes
+
+    # Verify ctypes module loads (depends on libffi)
+    assert hasattr(ctypes, 'c_int'), "missing c_int type"
+    assert hasattr(ctypes, 'CDLL'), "missing CDLL"
+
+    # Test basic ctypes type operations
+    val = ctypes.c_int(42)
+    assert val.value == 42, f"c_int value mismatch: {val.value}"
+
+    arr_type = ctypes.c_int * 3
+    arr = arr_type(1, 2, 3)
+    assert list(arr) == [1, 2, 3], f"array mismatch: {list(arr)}"
+
+    print("libffi: PASS")
+except Exception as e:
+    print(f"libffi: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Integrates [nanvix/libffi](https://github.com/nanvix/libffi) 3.4.6 as a statically compiled C library. Enables CPython's `ctypes` module.

- Submodule: `deps/libffi` (nanvix/v3.4.6, shallow)
- Build: autogen + configure + cross-compile `libffi.a`
- Test: `test_105_libffi.py` — ctypes basic operations
- Docs: `patches/libffi_static.md`