### PR TITLE
fix: filter runtime artifact selection by NANVIX_MEMORY_SIZE

### DIFF
--- a/z
+++ b/z
@@ -86,11 +86,11 @@ cmd_setup() {
 
   # Find and extract the matching platform artifact
   local nanvix_archive
-  nanvix_archive="$(find "$nanvix_artifacts" -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "${NANVIX_PLATFORM}.*${NANVIX_PROCESS_MODE}" | head -1)"
+  nanvix_archive="$(find "$nanvix_artifacts" -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "${NANVIX_PLATFORM}.*${NANVIX_PROCESS_MODE}.*${NANVIX_MEMORY_SIZE}" | head -1)"
   if [[ -z "$nanvix_archive" ]]; then
-    nanvix_archive="$(find "$nanvix_artifacts" -maxdepth 1 -type f -name "*.tar.bz2" | head -1)"
+    nanvix_archive="$(find "$nanvix_artifacts" -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "${NANVIX_PLATFORM}.*${NANVIX_PROCESS_MODE}" | head -1)"
   fi
-  [[ -z "$nanvix_archive" ]] && die "no Nanvix artifact found for ${NANVIX_PLATFORM}-${NANVIX_PROCESS_MODE}"
+  [[ -z "$nanvix_archive" ]] && die "no Nanvix artifact found for ${NANVIX_PLATFORM}-${NANVIX_PROCESS_MODE}-${NANVIX_MEMORY_SIZE}"
   log "extracting Nanvix runtime: $(basename "$nanvix_archive")"
   tar -xjf "$nanvix_archive" -C "$SYSROOT" --strip-components=0
 


### PR DESCRIPTION
## Problem

Workflow run [#23018364617](https://github.com/nanvix/nanvix-python/actions/runs/23018364617) failed because the `hyperlight-multi-process` job selected the wrong Nanvix runtime artifact.

The artifact selection at `z:89` used:
```bash
find ... | grep -E "${NANVIX_PLATFORM}.*${NANVIX_PROCESS_MODE}" | head -1
```

This matched **all** memory-size variants (128mb, 256mb, 512mb, 1024mb), then picked whichever `find` returned first (non-deterministic order). In the failing run it picked the `1024mb` variant, which caused `nanvixd` to fail with `Error: virtual machine failed` — the 1024mb VM exceeds the GitHub Actions runner resource limits.

## Fix

Include `NANVIX_MEMORY_SIZE` (default: `128mb`) in the primary grep pattern so the correct memory-size artifact is selected deterministically. A fallback to platform+process-mode only is kept in case the exact memory-size variant isn't available.