### PR TITLE
Add python-pptx support with pure-Python PIL shim

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -173,6 +173,12 @@ class NanvixPythonBuild(ZScript):
         if site_sentinel.is_file():
             h.update(site_sentinel.read_bytes())
 
+        # Factor in PIL shim sources
+        pil_shim = self.repo_root / "patches" / "PIL"
+        if pil_shim.is_dir():
+            for src in sorted(pil_shim.rglob("*.py")):
+                h.update(src.read_bytes())
+
         # Factor in test scripts
         for src in sorted(sysroot.glob("smoke_test_l2.py")):
             h.update(src.read_bytes())

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -497,6 +497,28 @@ class NanvixPythonBuild(ZScript):
         shutil.copytree(pil_src, pil_dst)
         log.info(f"installed PIL shim into {pil_dst}")
 
+    def _patch_openpyxl_lxml(self, site_pkg: Path) -> None:
+        """Disable lxml usage in openpyxl.
+
+        The Nanvix lxml binary does not provide the full API (e.g.
+        lxml.etree.xmlfile is missing).  Force openpyxl to use the
+        pure-Python et_xmlfile fallback instead.
+        """
+        xml_init = site_pkg / "openpyxl" / "xml" / "__init__.py"
+        if not xml_init.is_file():
+            return
+        content = xml_init.read_text()
+        if "LXML = False" in content:
+            return
+        # Replace the dynamic lxml detection with a forced False
+        patched = content.replace(
+            "LXML = lxml_available() and lxml_env_set()",
+            "LXML = False  # Nanvix: lxml lacks xmlfile; use et_xmlfile fallback",
+        )
+        if patched != content:
+            xml_init.write_text(patched)
+            log.info("patched openpyxl to disable lxml (missing xmlfile)")
+
     # ------------------------------------------------------------------
     # Lifecycle hooks
     # ------------------------------------------------------------------
@@ -602,6 +624,9 @@ class NanvixPythonBuild(ZScript):
         # Install PIL shim (pure-Python Pillow replacement for python-pptx)
         self._install_pil_shim(site_pkg)
 
+        # Patch openpyxl to use et_xmlfile instead of lxml.etree.xmlfile
+        self._patch_openpyxl_lxml(site_pkg)
+
         # Build ramfs image for standalone deployment
         if self.config.deployment_mode == "standalone":
             self._ensure_ramfs(sysroot)
@@ -645,6 +670,8 @@ class NanvixPythonBuild(ZScript):
         site_pkg = sysroot / "lib" / "python3.12" / "site-packages"
         site_pkg.mkdir(parents=True, exist_ok=True)
         self._install_site_packages(site_pkg)
+        self._install_pil_shim(site_pkg)
+        self._patch_openpyxl_lxml(site_pkg)
 
         # Copy test scripts into sysroot
         tests_dir = self.repo_root / "tests"

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -481,6 +481,22 @@ class NanvixPythonBuild(ZScript):
 
         sentinel.write_text(req_hash)
 
+    def _install_pil_shim(self, site_pkg: Path) -> None:
+        """Copy the pure-Python PIL shim into site-packages.
+
+        Replaces Pillow's C extension with lightweight header-only
+        parsing that python-pptx needs for image handling.
+        """
+        pil_src = self.repo_root / "patches" / "PIL"
+        pil_dst = site_pkg / "PIL"
+        if not pil_src.is_dir():
+            log.warning("patches/PIL not found; skipping PIL shim installation")
+            return
+        if pil_dst.exists():
+            shutil.rmtree(pil_dst)
+        shutil.copytree(pil_src, pil_dst)
+        log.info(f"installed PIL shim into {pil_dst}")
+
     # ------------------------------------------------------------------
     # Lifecycle hooks
     # ------------------------------------------------------------------
@@ -582,6 +598,9 @@ class NanvixPythonBuild(ZScript):
         site_pkg = sysroot / "lib" / "python3.12" / "site-packages"
         site_pkg.mkdir(parents=True, exist_ok=True)
         self._install_site_packages(site_pkg)
+
+        # Install PIL shim (pure-Python Pillow replacement for python-pptx)
+        self._install_pil_shim(site_pkg)
 
         # Build ramfs image for standalone deployment
         if self.config.deployment_mode == "standalone":

--- a/patches/PIL/Image.py
+++ b/patches/PIL/Image.py
@@ -1,0 +1,207 @@
+"""Pure-Python image metadata reader for NanVix.
+
+Parses PNG, JPEG, GIF, BMP, and TIFF headers to extract dimensions and
+color mode — the minimum python-pptx needs from PIL.Image.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+from pathlib import Path
+
+MAX_IMAGE_HEADER_BYTES = 1 << 20  # 1 MiB
+MAX_IMAGE_DIMENSION = 100_000
+MAX_IMAGE_PIXELS = 100_000_000
+
+
+def _validate_size(width: int, height: int) -> None:
+    if width <= 0 or height <= 0:
+        raise ValueError(f"Invalid image dimensions: {width}x{height}")
+    if width > MAX_IMAGE_DIMENSION or height > MAX_IMAGE_DIMENSION:
+        raise ValueError(
+            f"Image dimension {max(width, height)} exceeds limit {MAX_IMAGE_DIMENSION}"
+        )
+    if width * height > MAX_IMAGE_PIXELS:
+        raise ValueError(
+            f"Image pixel count {width * height} exceeds limit {MAX_IMAGE_PIXELS}"
+        )
+
+
+class Image:
+    """Minimal image metadata container."""
+
+    def __init__(self) -> None:
+        self.format: str | None = None
+        self.size: tuple[int, int] = (0, 0)
+        self.mode: str = "RGB"
+        self.color: str | tuple | None = None
+        self.info: dict = {}
+        self._fp: io.BytesIO | None = None
+
+    @property
+    def width(self) -> int:
+        return self.size[0]
+
+    @property
+    def height(self) -> int:
+        return self.size[1]
+
+    def close(self) -> None:
+        self._fp = None
+
+    def save(self, fp, format=None, **kwargs):
+        raise NotImplementedError("NanVix PIL shim does not support saving images")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def _read_all_bytes(fp) -> bytes:
+    data = fp.read(MAX_IMAGE_HEADER_BYTES)
+    if len(data) >= MAX_IMAGE_HEADER_BYTES:
+        raise ValueError("Image header exceeds maximum allowed size")
+    return data
+
+
+def _parse_png(data: bytes) -> Image:
+    if len(data) < 24:
+        raise ValueError("PNG header too short")
+    w = struct.unpack(">I", data[16:20])[0]
+    h = struct.unpack(">I", data[20:24])[0]
+    _validate_size(w, h)
+    bit_depth = data[24] if len(data) > 24 else 8
+    color_type = data[25] if len(data) > 25 else 2
+    mode_map = {0: "L", 2: "RGB", 3: "P", 4: "LA", 6: "RGBA"}
+    img = Image()
+    img.format = "PNG"
+    img.size = (w, h)
+    img.mode = mode_map.get(color_type, "RGB")
+    return img
+
+
+def _parse_jpeg(data: bytes) -> Image:
+    i = 2
+    while i < len(data) - 1:
+        if data[i] != 0xFF:
+            i += 1
+            continue
+        marker = data[i + 1]
+        if marker == 0xFF:
+            i += 1
+            continue
+        if marker == 0x00 or marker == 0xD8:
+            i += 2
+            continue
+        if i + 3 >= len(data):
+            break
+        seglen = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+            if seglen >= 8 and i + 9 < len(data):
+                h = struct.unpack(">H", data[i + 5 : i + 7])[0]
+                w = struct.unpack(">H", data[i + 7 : i + 9])[0]
+                ncomp = data[i + 9] if i + 9 < len(data) else 3
+                _validate_size(w, h)
+                img = Image()
+                img.format = "JPEG"
+                img.size = (w, h)
+                img.mode = {1: "L", 3: "RGB", 4: "CMYK"}.get(ncomp, "RGB")
+                return img
+        i += 2 + seglen
+    raise ValueError("No SOF marker found in JPEG")
+
+
+def _parse_gif(data: bytes) -> Image:
+    if len(data) < 10:
+        raise ValueError("GIF header too short")
+    w = struct.unpack("<H", data[6:8])[0]
+    h = struct.unpack("<H", data[8:10])[0]
+    _validate_size(w, h)
+    img = Image()
+    img.format = "GIF"
+    img.size = (w, h)
+    img.mode = "P"
+    return img
+
+
+def _parse_bmp(data: bytes) -> Image:
+    if len(data) < 26:
+        raise ValueError("BMP header too short")
+    w = abs(struct.unpack("<i", data[18:22])[0])
+    h = abs(struct.unpack("<i", data[22:26])[0])
+    _validate_size(w, h)
+    img = Image()
+    img.format = "BMP"
+    img.size = (w, h)
+    img.mode = "RGB"
+    return img
+
+
+def _parse_tiff(data: bytes) -> Image:
+    bo = "<" if data[:2] == b"II" else ">"
+    ifd_offset = struct.unpack(f"{bo}I", data[4:8])[0]
+    if ifd_offset + 2 > len(data):
+        raise ValueError("TIFF IFD offset out of range")
+    num_entries = struct.unpack(f"{bo}H", data[ifd_offset : ifd_offset + 2])[0]
+    w = h = 0
+    for j in range(num_entries):
+        off = ifd_offset + 2 + j * 12
+        if off + 12 > len(data):
+            break
+        tag = struct.unpack(f"{bo}H", data[off : off + 2])[0]
+        val = struct.unpack(f"{bo}I", data[off + 8 : off + 12])[0]
+        if tag == 256:
+            w = val
+        elif tag == 257:
+            h = val
+    if w and h:
+        _validate_size(w, h)
+    img = Image()
+    img.format = "TIFF"
+    img.size = (w, h)
+    img.mode = "RGB"
+    return img
+
+
+_PARSERS = [
+    (b"\x89PNG\r\n\x1a\n", _parse_png),
+    (b"\xff\xd8\xff", _parse_jpeg),
+    (b"GIF87a", _parse_gif),
+    (b"GIF89a", _parse_gif),
+    (b"BM", _parse_bmp),
+    (b"II", _parse_tiff),
+    (b"MM", _parse_tiff),
+]
+
+
+def open(fp, mode="r"):
+    if isinstance(fp, (str, Path)):
+        with builtins_open(str(fp), "rb") as f:
+            data = _read_all_bytes(f)
+    elif hasattr(fp, "read"):
+        data = _read_all_bytes(fp)
+    else:
+        raise TypeError(f"Unsupported argument type: {type(fp)}")
+
+    for sig, parser in _PARSERS:
+        if data[: len(sig)] == sig:
+            img = parser(data)
+            img._fp = io.BytesIO(data)
+            return img
+    raise ValueError("Unrecognized image format")
+
+
+def new(mode, size, color=0):
+    _validate_size(size[0], size[1])
+    img = Image()
+    img.mode = mode
+    img.size = tuple(size)
+    img.color = color
+    return img
+
+
+import builtins as _builtins
+builtins_open = _builtins.open

--- a/patches/PIL/Image.py
+++ b/patches/PIL/Image.py
@@ -61,9 +61,9 @@ class Image:
 
 
 def _read_all_bytes(fp) -> bytes:
-    data = fp.read(MAX_IMAGE_HEADER_BYTES)
-    if len(data) >= MAX_IMAGE_HEADER_BYTES:
-        raise ValueError("Image header exceeds maximum allowed size")
+    data = fp.read(MAX_IMAGE_HEADER_BYTES + 1)
+    if len(data) > MAX_IMAGE_HEADER_BYTES:
+        data = data[:MAX_IMAGE_HEADER_BYTES]
     return data
 
 
@@ -141,6 +141,8 @@ def _parse_bmp(data: bytes) -> Image:
 
 
 def _parse_tiff(data: bytes) -> Image:
+    if len(data) < 8:
+        raise ValueError("TIFF header too short")
     bo = "<" if data[:2] == b"II" else ">"
     ifd_offset = struct.unpack(f"{bo}I", data[4:8])[0]
     if ifd_offset + 2 > len(data):

--- a/patches/PIL/ImageColor.py
+++ b/patches/PIL/ImageColor.py
@@ -15,8 +15,8 @@ def getrgb(color: str) -> tuple[int, ...]:
     low = color.strip().lower()
     if low in _NAMED_COLORS:
         return _NAMED_COLORS[low]
-    if color.startswith("#"):
-        h = color[1:]
+    if low.startswith("#"):
+        h = low[1:]
         if len(h) == 3:
             return tuple(int(c * 2, 16) for c in h)
         if len(h) == 6:

--- a/patches/PIL/ImageColor.py
+++ b/patches/PIL/ImageColor.py
@@ -1,0 +1,26 @@
+"""Minimal color name/hex parser for python-pptx."""
+
+from __future__ import annotations
+
+_NAMED_COLORS = {
+    "red": (255, 0, 0), "green": (0, 128, 0), "blue": (0, 0, 255),
+    "white": (255, 255, 255), "black": (0, 0, 0), "yellow": (255, 255, 0),
+    "cyan": (0, 255, 255), "magenta": (255, 0, 255), "gray": (128, 128, 128),
+    "grey": (128, 128, 128), "orange": (255, 165, 0), "purple": (128, 0, 128),
+    "pink": (255, 192, 203), "brown": (165, 42, 42), "lime": (0, 255, 0),
+}
+
+
+def getrgb(color: str) -> tuple[int, ...]:
+    low = color.strip().lower()
+    if low in _NAMED_COLORS:
+        return _NAMED_COLORS[low]
+    if color.startswith("#"):
+        h = color[1:]
+        if len(h) == 3:
+            return tuple(int(c * 2, 16) for c in h)
+        if len(h) == 6:
+            return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+        if len(h) == 8:
+            return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16), int(h[6:8], 16))
+    raise ValueError(f"Unknown color: {color!r}")

--- a/patches/PIL/ImageFont.py
+++ b/patches/PIL/ImageFont.py
@@ -1,0 +1,32 @@
+"""Pure-Python font metrics for NanVix.
+
+Provides deterministic text metrics used by python-pptx layout code when
+computing text box dimensions.  No actual font rendering.
+"""
+
+from __future__ import annotations
+
+
+class FreeTypeFont:
+    """Minimal font metrics stub."""
+
+    def __init__(self, font=None, size=10, index=0, encoding="", layout_engine=None):
+        self.size = size
+        self.path = font
+
+    def getlength(self, text, mode="", direction="", features=None, language=None):
+        return len(text) * self.size * 0.6
+
+    def getbbox(self, text, mode="", direction="", features=None, language=None, anchor=None):
+        w = self.getlength(text)
+        return (0, 0, int(w), int(self.size * 1.2))
+
+    getsize = getbbox
+
+
+def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
+    return FreeTypeFont(font=font, size=size, index=index, encoding=encoding)
+
+
+def load_default():
+    return FreeTypeFont(size=10)

--- a/patches/PIL/ImageFont.py
+++ b/patches/PIL/ImageFont.py
@@ -21,7 +21,9 @@ class FreeTypeFont:
         w = self.getlength(text)
         return (0, 0, int(w), int(self.size * 1.2))
 
-    getsize = getbbox
+    def getsize(self, text, *args, **kwargs):
+        w = self.getlength(text)
+        return (int(w), int(self.size * 1.2))
 
 
 def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):

--- a/patches/PIL/ImageOps.py
+++ b/patches/PIL/ImageOps.py
@@ -1,0 +1,8 @@
+"""Minimal ImageOps for python-pptx compatibility."""
+
+from __future__ import annotations
+
+
+def exif_transpose(image):
+    """No-op — NanVix PIL shim does not handle EXIF rotation."""
+    return image

--- a/patches/PIL/__init__.py
+++ b/patches/PIL/__init__.py
@@ -4,3 +4,5 @@ Replaces Pillow's C extension (_imaging) with pure-Python image header
 parsing.  Covers the subset of PIL that python-pptx uses at import time
 and for slide image handling.
 """
+
+__version__ = "10.0.0"

--- a/patches/PIL/__init__.py
+++ b/patches/PIL/__init__.py
@@ -1,0 +1,6 @@
+"""NanVix PIL — lightweight pure-Python image library for python-pptx.
+
+Replaces Pillow's C extension (_imaging) with pure-Python image header
+parsing.  Covers the subset of PIL that python-pptx uses at import time
+and for slide image handling.
+"""

--- a/requirements/site-packages-extra.txt
+++ b/requirements/site-packages-extra.txt
@@ -43,6 +43,9 @@ plotly==5.20.0
 xlrd==2.0.1
 xlsxwriter
 
+# Document generation
+python-pptx==1.0.2
+
 # Runtime and typing helpers
 blinker
 catalogue==2.0.10

--- a/tests/func/test_106_python_pptx.py
+++ b/tests/func/test_106_python_pptx.py
@@ -1,0 +1,24 @@
+"""Test: python-pptx"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import lxml  # noqa: F401 — hard dependency of python-pptx
+except ImportError:
+    print("python-pptx: SKIP (lxml not available)")
+    sys.exit(0)
+try:
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    prs = Presentation()
+    slide_layout = prs.slide_layouts[0]
+    slide = prs.slides.add_slide(slide_layout)
+    title = slide.shapes.title
+    title.text = "NanVix Test"
+
+    assert len(prs.slides) == 1
+    assert title.text == "NanVix Test"
+    print("python-pptx: PASS")
+except Exception as e:
+    print(f"python-pptx: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Add python-pptx==1.0.2 to requirements for PowerPoint file creation.

Include a lightweight pure-Python PIL shim (patches/PIL/) that replaces Pillow's C extension with header-only image parsing. Covers the subset python-pptx needs: Image.open, ImageFont, ImageColor, ImageOps.

The PIL shim is copied into site-packages during build, before .pyc pre-compilation.

Dependencies already present: typing-extensions, xlsxwriter, et-xmlfile. lxml comes from the CPython binary (nanvix/cpython PR #547).