### PR TITLE
[ci] Sync zutils v0.7.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.26"
+      zutil-version: "v0.7.27"
       platforms: "[\"microvm\"]"
       process-modes: "[\"standalone\"]"
       memory-sizes: "[\"256mb\"]"

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanvix-python"
 version = "3.12.3"
-nanvix-version = "0.12.490"
+nanvix-version = "0.12.491"
 
 [builds]
 [builds.matrix]

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.26"
+    "0.7.27"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -27,7 +27,9 @@ $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
-# which are unavailable on Windows. Stub them before importing the package.
+# which are unavailable on Windows.  Stub them before importing the package.
+# NOTE: Use single quotes inside the Python code so that PowerShell does not
+# strip the quotes when passing the string to python.exe -c.
 $ShimCode = @'
 import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
@@ -116,10 +118,41 @@ else {
     }
 }
 
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+$filteredArray = $filteredArgs.ToArray()
+
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @ZArgs
+    & $venvPython -c $ShimCode @filteredArray
 }
 else {
-    & $bin @ZArgs
+    & $bin @filteredArray
 }
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.26"
+PINNED_VERSION="0.7.27"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -72,4 +72,39 @@ else
     fi
 fi
 
-exec "$BIN" "$@"
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+# The nanvix-zutil CLI inspects positional args to find the subcommand;
+# --with-nanvix's PATH argument would be mistaken for a subcommand.
+# Pass the value via env var so z.py can pick it up.
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+exec "$BIN" "${ARGS[@]}"


### PR DESCRIPTION
Automated sync with [`v0.7.27`](https://github.com/nanvix/zutils/releases/tag/v0.7.27):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.12.491` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.