### PR TITLE
[ci] Reuse Linux-built ramfs for Windows test + bump zutils to v0.7.34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,72 @@ jobs:
       process-modes: "[\"standalone\"]"
       memory-sizes: "[\"256mb\"]"
       caller-event-name: ${{ github.event_name }}
+      windows-test: false
       release-notes-extra: |
         CPython 3.12.3 distribution for Nanvix with pure Python pip packages.
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+  # Custom Windows test that reuses the ramfs image from the Linux build
+  # instead of rebuilding it (Docker can't run the Linux toolchain image
+  # on Windows CI runners, so .py→.pyc pre-compilation would be skipped).
+  windows-test:
+    needs: ci
+    if: >-
+      !cancelled()
+      && needs.ci.result == 'success'
+    runs-on: windows-latest
+    env:
+      NANVIX_MACHINE: microvm
+      NANVIX_DEPLOYMENT_MODE: standalone
+      NANVIX_MEMORY_SIZE: 256mb
+      NANVIX_VERSION: ${{ needs.ci.outputs.nanvix_tag }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          NANVIX_ZUTIL_VERSION: "v0.7.34"
+        shell: pwsh
+        run: |
+          $jq = '.assets[] | select(.name | endswith(".whl")) | .browser_download_url'
+          $wheel = gh api "repos/nanvix/zutils/releases/tags/$env:NANVIX_ZUTIL_VERSION" --jq $jq
+          python -m pip install $wheel
+
+      - name: Setup
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: nanvix-zutil setup
+
+      - name: Download Linux build artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: >-
+            nanvix-python-${{ needs.ci.outputs.package_version }}-x86-microvm-standalone-256mb
+          path: linux-build
+
+      - name: Extract ramfs from Linux tarball
+        shell: pwsh
+        run: |
+          $tarball = Get-ChildItem linux-build -Filter "*.tar.bz2" | Select-Object -First 1
+          Write-Host "Extracting ramfs from $($tarball.Name)"
+          tar -xjf $tarball.FullName -C linux-build
+          $ramfs = Get-ChildItem linux-build -Recurse -Filter "nanvix_rootfs.img" | Select-Object -First 1
+          if (-not $ramfs) { Write-Error "nanvix_rootfs.img not found in tarball"; exit 1 }
+          $dest = Join-Path $env:GITHUB_WORKSPACE ".nanvix" "nanvix_rootfs.img"
+          New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+          Copy-Item $ramfs.FullName $dest
+          Write-Host "Placed ramfs at $dest ($('{0:N0}' -f (Get-Item $dest).Length) bytes)"
+          echo "NANVIX_PREBUILT_RAMFS=$dest" >> $env:GITHUB_ENV
+
+      - name: Test
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: nanvix-zutil test
 
   release:
     needs: ci

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -594,9 +594,22 @@ class NanvixPythonBuild(ZScript):
             shutil.copy2(t, sysroot)
 
         # Build ramfs for standalone mode (needed fresh each test run
-        # since test scripts are copied into it)
+        # since test scripts are copied into it).
+        # When NANVIX_PREBUILT_RAMFS is set (e.g. by CI to reuse the
+        # Linux-built ramfs on Windows), skip the rebuild entirely.
         if deployment == "standalone":
-            self._ensure_ramfs(sysroot)
+            prebuilt = os.environ.get("NANVIX_PREBUILT_RAMFS")
+            if prebuilt:
+                p = Path(prebuilt)
+                if not p.is_file():
+                    log.fatal(
+                        f"NANVIX_PREBUILT_RAMFS points to non-existent file: {p}",
+                        code=EXIT_MISSING_DEP,
+                    )
+                log.info(f"using pre-built ramfs: {p}")
+                self._ramfs_img = p
+            else:
+                self._ensure_ramfs(sysroot)
 
         # Standalone exclusions
         exclude_tests = os.environ.get("EXCLUDE_TESTS", "")


### PR DESCRIPTION
- Bump zutils to v0.7.34 (Windows Docker fix for setup)
- Reuse Linux-built ramfs (with .pyc pre-compilation) for Windows test instead of rebuilding
- Add NANVIX_PREBUILT_RAMFS env var support in test()
- Custom windows-test job extracts ramfs from Linux build tarball