### PR TITLE
ci: add format & lint job via zutils reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       memory-sizes: "[\"256mb\"]"
       caller-event-name: ${{ github.event_name }}
       windows-test: false
+      python-paths: ".nanvix/z.py tests/smoke_test_l2.py"
       release-notes-extra: |
         CPython 3.12.3 distribution for Nanvix with pure Python pip packages.
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
   repository_dispatch:
-    types: [ cpython-release ]
+    types: [cpython-release]
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main", "nanvix/**" ]
+    branches: ["main", "nanvix/**"]
   workflow_dispatch:
 
 permissions:
@@ -35,6 +35,7 @@ jobs:
       caller-event-name: ${{ github.event_name }}
       windows-test: false
       python-paths: ".nanvix/z.py tests/smoke_test_l2.py"
+      yaml-paths: ".github/workflows/ci.yml"
       release-notes-extra: |
         CPython 3.12.3 distribution for Nanvix with pure Python pip packages.
     secrets:
@@ -136,12 +137,14 @@ jobs:
           find release-artifacts \( -name "*.tar.bz2" -o -name "*.zip" \) \
             -exec cp {} release-assets/ \; 2>/dev/null || true
 
-          printf -v NOTES 'Automated build from branch %s.\n\n**Build:** [#%s](%s)\n**Commit:** [`%s`](%s)\n\nCPython 3.12.3 distribution for Nanvix with pure Python pip packages.' \
-            "${{ github.ref_name }}" \
+          NOTES=$(printf 'Automated build from branch %s.\n\n' "${{ github.ref_name }}")
+          NOTES+=$(printf '**Build:** [#%s](%s)\n' \
             "${{ github.run_number }}" \
-            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          NOTES+=$(printf '**Commit:** [`%s`](%s)\n\n' \
             "${GITHUB_SHA::7}" \
-            "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+            "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}")
+          NOTES+="CPython 3.12.3 distribution for Nanvix with pure Python pip packages."
 
           # Collect assets safely (nullglob prevents literal glob on empty dir)
           shopt -s nullglob
@@ -176,7 +179,7 @@ jobs:
           fi
 
   windows-release:
-    needs: [ ci, release ]
+    needs: [ci, release]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:

--- a/tests/smoke_test_l2.py
+++ b/tests/smoke_test_l2.py
@@ -4,6 +4,7 @@ Tests the modules that are compiled into cpython via Layer 1 libraries:
   zlib, bz2, _ssl/hashlib, _sqlite3, _ctypes, pyexpat, _elementtree
 Plus basic stdlib functionality: sys, os, json, collections, math, io.
 """
+
 import sys
 
 sys.stdout.reconfigure(line_buffering=True)
@@ -25,6 +26,7 @@ except Exception as e:
 # os
 try:
     import os
+
     assert hasattr(os, "getcwd")
     results.append(("os", "PASS"))
 except Exception as e:
@@ -33,6 +35,7 @@ except Exception as e:
 # json
 try:
     import json
+
     data = json.loads('{"key": "value", "num": 42}')
     assert data["key"] == "value" and data["num"] == 42
     assert json.dumps(data, sort_keys=True) == '{"key": "value", "num": 42}'
@@ -43,6 +46,7 @@ except Exception as e:
 # collections
 try:
     from collections import OrderedDict, Counter, defaultdict
+
     c = Counter("abracadabra")
     assert c["a"] == 5
     results.append(("collections", "PASS"))
@@ -52,6 +56,7 @@ except Exception as e:
 # math
 try:
     import math
+
     assert abs(math.pi - 3.141592653589793) < 1e-10
     assert math.sqrt(144) == 12.0
     results.append(("math", "PASS"))
@@ -61,6 +66,7 @@ except Exception as e:
 # io
 try:
     import io
+
     buf = io.StringIO()
     buf.write("hello")
     assert buf.getvalue() == "hello"
@@ -73,6 +79,7 @@ except Exception as e:
 # zlib (L1: zlib)
 try:
     import zlib
+
     data = b"hello world" * 100
     compressed = zlib.compress(data)
     assert zlib.decompress(compressed) == data
@@ -83,6 +90,7 @@ except Exception as e:
 # bz2 (L1: bzip2)
 try:
     import bz2
+
     data = b"hello bzip2 world" * 50
     compressed = bz2.compress(data)
     assert bz2.decompress(compressed) == data
@@ -93,6 +101,7 @@ except Exception as e:
 # hashlib / _ssl (L1: openssl)
 try:
     import hashlib
+
     h = hashlib.sha256(b"hello").hexdigest()
     assert len(h) == 64
     results.append(("hashlib", "PASS"))
@@ -102,6 +111,7 @@ except Exception as e:
 # sqlite3 (L1: sqlite)
 try:
     import sqlite3
+
     conn = sqlite3.connect(":memory:")
     cur = conn.cursor()
     cur.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)")
@@ -116,6 +126,7 @@ except Exception as e:
 # ctypes (L1: libffi)
 try:
     import ctypes
+
     assert hasattr(ctypes, "c_int")
     v = ctypes.c_int(42)
     assert v.value == 42
@@ -126,6 +137,7 @@ except Exception as e:
 # pyexpat / xml.parsers.expat (L1: libexpat)
 try:
     import xml.parsers.expat
+
     parser = xml.parsers.expat.ParserCreate()
     elements = []
     parser.StartElementHandler = lambda name, attrs: elements.append(name)
@@ -138,6 +150,7 @@ except Exception as e:
 # xml.etree.ElementTree (uses _elementtree C accelerator, L1: libexpat)
 try:
     import xml.etree.ElementTree as ET
+
     root = ET.fromstring("<root><child>text</child></root>")
     assert root.find("child").text == "text"
     results.append(("xml.etree", "PASS"))


### PR DESCRIPTION
Adds a `format-and-lint` job that calls `nanvix/zutils/.github/workflows/nanvix-ci.yml` to check Python formatting (black), type-checking (pyright), shell formatting (shfmt), shell linting (shellcheck), and YAML linting (yamllint).

Includes `tests/smoke_test_l2.py` in the Python format-check scope via `python-paths` input.

Depends on: https://github.com/nanvix/zutils/pull/159