### PR TITLE
[ci] E: Update nanvix workflow refs to v1.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.42"
       platforms: "[\"microvm\"]"


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.14.0`](https://github.com/nanvix/workflows/releases/tag/v1.14.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.