### PR TITLE
ci: enable hyperlight standalone in build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.44"
-      platforms: "[\"microvm\"]"
+      platforms: '["hyperlight","microvm"]'
       process-modes: "[\"standalone\"]"
       memory-sizes: "[\"256mb\"]"
       caller-event-name: ${{ github.event_name }}

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -5,7 +5,7 @@ nanvix-version = "0.12.529"
 
 [builds]
 [builds.matrix]
-platforms = ["microvm"]
+platforms = ["hyperlight", "microvm"]
 modes = ["standalone"]
 memory = ["256mb"]
 


### PR DESCRIPTION
## Summary

- Add hyperlight to the platforms list in `nanvix.toml` and CI workflow
- Since process-modes is already standalone-only, no matrix-exclude is needed — hyperlight will only build in standalone mode

Depends on the Hyperlight HAL frame allocator fix in nanvix/nanvix which resolves the `frame allocator storage too small for sparse layout` kernel panic in standalone mode.