### PR TITLE
srt: add srt==3.5.3 to site-packages-base + smoke test

### DIFF
--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -30,6 +30,7 @@ markdown-it-py==4.0.0
 MarkupSafe==2.1.5
 mdurl==0.1.2
 pygments
+srt==3.5.3
 striprtf==0.0.20
 tabulate==0.8.10
 

--- a/tests/func/test_108_srt.py
+++ b/tests/func/test_108_srt.py
@@ -1,0 +1,25 @@
+"""Test: srt"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import srt
+    import textwrap
+    sample = textwrap.dedent("""\
+        1
+        00:00:01,000 --> 00:00:02,000
+        hello
+
+        2
+        00:00:03,000 --> 00:00:04,500
+        world
+        """)
+    subs = list(srt.parse(sample))
+    assert len(subs) == 2
+    assert subs[0].content == "hello"
+    assert subs[1].index == 2
+    # round-trip
+    assert list(srt.parse(srt.compose(subs))) == subs
+    print("srt: PASS")
+except Exception as e:
+    print(f"srt: FAIL: {e}")
+    sys.exit(1)

--- a/tests/func/test_108_srt.py
+++ b/tests/func/test_108_srt.py
@@ -4,6 +4,7 @@ sys.stdout.reconfigure(line_buffering=True)
 try:
     import srt
     import textwrap
+    from datetime import timedelta
     sample = textwrap.dedent("""\
         1
         00:00:01,000 --> 00:00:02,000
@@ -17,6 +18,10 @@ try:
     assert len(subs) == 2
     assert subs[0].content == "hello"
     assert subs[1].index == 2
+    # timecode parsing (datetime/timedelta path)
+    assert subs[0].start == timedelta(seconds=1)
+    assert subs[0].end == timedelta(seconds=2)
+    assert subs[1].end - subs[1].start == timedelta(milliseconds=1500)
     # round-trip
     assert list(srt.parse(srt.compose(subs))) == subs
     print("srt: PASS")


### PR DESCRIPTION
Closes #110.

## What

Adds the [`srt`](https://pypi.org/project/srt/) (3.5.3) pure-Python
SubRip parser to the Nanvix CPython port:

- Appends `srt==3.5.3` to `requirements/site-packages-base.txt` under
  the existing **Markup and rendering** section, alphabetically between
  `pygments` and `striprtf==0.0.20`.
- Adds `tests/func/test_108_srt.py` — a single-file smoke test in the
  canonical `test_NNN_<pkg>.py` shape (cf. `tests/func/test_020_click.py`).
  It parses a two-cue inline sample, asserts on the resulting `Subtitle`
  fields, and round-trips via `srt.compose` / `srt.parse`.

Two-line diff: one `requirements/` line, one new test file. No edits to
`.nanvix/`, `patches/`, `Modules/Setup.local`, or any other manifest.

## Why

`srt` is upstream Tier-1 trivial: 511 LOC, single-file, stdlib surface
is `re` / `datetime` / `functools` / `logging` / `io` — all enabled on
Nanvix CPython. No stdlib gap, no patch, no shim. The host-side
`pip install --target` flow driven by `requirements/site-packages-*.txt`
already handles everything; this PR just wires `srt` into it.

## Decisions

Resolved during design (full record in the vault under
`process/designs/port-srt/design.md`); summarized inline because the
vault is private to the working tree:

- **Install pathway.** Use the existing pure-Python manifest
  (`requirements/site-packages-{base,extra}.txt`) plus the host-side
  `pip install --target` step in `.nanvix/z.py`. No new `.nanvix/srt.py`,
  no `patches/srt/`, no vendored copy.
- **`-base` vs `-extra` bucket.** `-base.txt` carries text/markup/parsing
  utilities (`markdown`, `markdown-it-py`, `MarkupSafe`, `pygments`,
  `striprtf`, `tabulate`); `-extra.txt` is application-level (Flask,
  requests, plotly, openpyxl). `srt` is a minimal text-format parser
  and slots in next to `striprtf`.
- **Acceptance bar.** Smoke-only, matching the existing
  `tests/func/test_NNN_<pkg>.py` convention. Upstream `srt`'s own
  pytest + hypothesis suite is intentionally **not** invoked from
  here — it tests Python semantics, not the Nanvix port.
- **`srt_tools/srt-*` console scripts.** Not retained. They drop with
  the existing `bin/` purge in `_create_stripped_sysroot`, consistent
  with every other shipped package.
- **Numbering.** `NNN = 108` chosen as `max+1` over `tests/func/`
  (previous high watermark: `test_107_hypothesis.py`).

## Test plan

Local verification per `AGENTS.md`, all three deployment modes, on
this branch's tip:

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=$MODE ./z setup; ./z build; ./z test
```

| MODE            | Result                                        | srt   |
| --------------- | --------------------------------------------- | ----- |
| standalone      | 101 passed, 0 failed, 0 skipped               | PASS  |
| single-process  | 104 passed, 0 failed, 0 skipped               | PASS  |
| multi-process   | 104 passed, 0 failed, 0 skipped               | PASS  |

CI exercises the full platform matrix per
`doc/contributing.md` step 5.

## Diff scope

- `requirements/site-packages-base.txt` — +1 line.
- `tests/func/test_108_srt.py` — new file, ~25 lines.

No other paths touched.

## Ramfs size increase

Measured on a clean tree (standalone mode), `./z distclean; ./z clean;
NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build` between two
builds — first with `srt==3.5.3` removed from
`requirements/site-packages-base.txt`, then restored:

|                                   |       baseline |     with `srt` | delta                          |
| --------------------------------- | -------------: | -------------: | ------------------------------ |
| ramfs image (`nanvix_rootfs.img`) |   84,795,392 B |   84,848,640 B | **+53,248 B (+52.0 KiB)**      |
| stripped-sysroot content          |   56,527,816 B |   56,563,228 B | +35,412 B (+34.6 KiB)          |
| files in ramfs                    |          4,784 |          4,788 | +4                             |

New ramfs paths:

- `lib/python3.12/site-packages/srt.pyc`
- `lib/python3.12/site-packages/srt_tools/__init__.pyc`
- `lib/python3.12/site-packages/srt_tools/utils.pyc`
- `lib/python3.12/site-packages/srt-3.5.3.dist-info/METADATA`

`srt`'s actual payload is ~35 KiB; the gap to +52 KiB on the image is
`mkramfs` block-alignment overhead. Net: **0.06 % of an 80.9 MiB image**.
The nine `srt_tools/srt-*` console scripts in `bin/` (~17 KiB) are dropped
by the existing `_create_stripped_sysroot` `bin/` purge and do not ship.

## Checklist

- [x] Two-path diff matches the design's `Files changed` table
- [x] Smoke test follows the `test_NNN_<pkg>.py` convention
- [x] `srt: PASS` verified locally in standalone, single-process, and
      multi-process modes
- [x] No `.nanvix/` / `patches/` / `Modules/Setup.local` edits
- [x] Ramfs size delta measured (see above)
- [x] Closes upstream issue #110
