### PR TITLE
iniconfig: add iniconfig==2.3.0 to site-packages-base + smoke test

### DIFF
--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -12,6 +12,7 @@ wheel==0.45.1
 
 # Typing and parsing
 annotated-types==0.7.0
+iniconfig==2.3.0
 ply==3.11
 pyparsing==3.1.1
 typing-extensions==4.15.0

--- a/tests/func/test_108_iniconfig.py
+++ b/tests/func/test_108_iniconfig.py
@@ -1,0 +1,23 @@
+"""Test: iniconfig"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import textwrap
+    import iniconfig
+    src = textwrap.dedent("""\
+        [section_a]
+        key1 = value1
+        key2 = value2
+
+        [section_b]
+        key3 = value3
+        """)
+    cfg = iniconfig.IniConfig("<in-memory>", data=src)
+    assert "section_a" in cfg
+    assert cfg["section_a"]["key1"] == "value1"
+    assert cfg["section_a"]["key2"] == "value2"
+    assert len(list(cfg)) == 2
+    print("iniconfig: PASS")
+except Exception as e:
+    print(f"iniconfig: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Ports `iniconfig` 2.3.0 by appending the package to the existing
pure-Python manifest (`requirements/site-packages-base.txt`,
"Typing and parsing" section) and adding a smoke test in the upstream
`tests/func/test_NNN_<pkg>.py` convention. `iniconfig` is a pure-Python,
single-file INI parser (~250 LOC, stdlib surface = built-ins + `pathlib`)
and a hard transitive dependency of `pytest`, so it is a stepping stone
toward broader test-tooling enablement on Nanvix.

Closes #96.

## Decisions

These follow the verdicts already established by the `srt` port:

- **Install pathway:** via the existing `requirements/site-packages-*.txt`
  + `pip --target` flow driven by `.nanvix/z.py`. No vendoring, no
  `Modules/Setup.local`, no `.nanvix/iniconfig.py`, no `patches/iniconfig/`.
- **Acceptance bar:** a single-file `tests/func/test_NNN_<pkg>.py` smoke
  test in the upstream convention; we do not run upstream's
  `pytest`+`hypothesis` suite.
- **Smoke-test shape:** the canonical `test_020_click.py` pattern —
  module docstring, `sys.stdout.reconfigure(line_buffering=True)`, single
  `try` block printing `<pkg>: PASS` on success and
  `<pkg>: FAIL: <e>` + `sys.exit(1)` on any exception.
- **Numbering:** `NNN = max+1` over `tests/func/`. Highest pre-existing
  test was `test_107_hypothesis.py`, so the new file is
  `test_108_iniconfig.py`.

## Ramfs delta

Standalone `nanvix_rootfs.img` grows by **28,672 bytes (~0.034%)** —
from 84,795,392 to 84,824,064 bytes — measured with
`./z distclean && ./z clean && NANVIX_DEPLOYMENT_MODE=standalone ./z setup && ./z build`
before and after this change.

## Test plan

Locally per `AGENTS.md` across all three deployment modes:

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=$MODE ./z setup; ./z build; ./z test
```

with `MODE` ∈ {`standalone`, `single-process`, `multi-process`}. In each
mode the new test prints `iniconfig: PASS` and the suite finishes green
(standalone: 90 passed / 0 failed / 11 skipped; single-process and
multi-process: 104 passed / 0 failed / 0 skipped).

CI exercises the four platform configs per `doc/contributing.md` step 5.
