### PR TITLE
schedule: add schedule==1.2.2 to site-packages-base + smoke test

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -25,6 +25,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | immutabledict      | —       |
 | ordered-set        | 4.1.0   |
 | packaging          | 23.2    |
+| schedule           | 1.2.2   |
 | setuptools         | 75.8.0  |
 | tenacity           | —       |
 | toolz              | 0.12.1  |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -4,6 +4,7 @@ filelock==3.20.0
 immutabledict
 ordered-set==4.1.0
 packaging==23.2
+schedule==1.2.2
 setuptools==75.8.0
 tenacity
 toolz==0.12.1

--- a/tests/func/test_108_schedule.py
+++ b/tests/func/test_108_schedule.py
@@ -7,13 +7,19 @@ try:
     def job():
         counter[0] += 1
     schedule.every(1).seconds.do(job)
-    time.sleep(1.1)
-    schedule.run_pending()
+    # Poll until the 1s-interval job fires or the deadline elapses.
+    deadline = time.monotonic() + 2.0
+    while counter[0] < 1 and time.monotonic() < deadline:
+        schedule.run_pending()
+        time.sleep(0.05)
     assert counter[0] >= 1, f"counter={counter[0]}"
     schedule.clear()
 
     import threading
-    lock = threading.Lock()
+    # Use RLock explicitly: this test is the canary for RLock availability
+    # on the Nanvix CPython port (schedule.Scheduler uses RLock internally
+    # to guard its job list).
+    lock = threading.RLock()
     mt = [0]
     stop = threading.Event()
     def mt_job():
@@ -26,7 +32,10 @@ try:
             time.sleep(0.05)
     worker = threading.Thread(target=worker_loop, daemon=True)
     worker.start()
-    time.sleep(1.5)
+    # Wait up to 2s for the worker thread to observe the job firing.
+    deadline = time.monotonic() + 2.0
+    while mt[0] < 1 and time.monotonic() < deadline:
+        time.sleep(0.05)
     stop.set()
     worker.join(timeout=2.0)
     assert not worker.is_alive(), "worker did not exit cleanly"

--- a/tests/func/test_108_schedule.py
+++ b/tests/func/test_108_schedule.py
@@ -11,6 +11,28 @@ try:
     schedule.run_pending()
     assert counter[0] >= 1, f"counter={counter[0]}"
     schedule.clear()
+
+    import threading
+    lock = threading.Lock()
+    mt = [0]
+    stop = threading.Event()
+    def mt_job():
+        with lock:
+            mt[0] += 1
+    schedule.every(1).seconds.do(mt_job)
+    def worker_loop():
+        while not stop.is_set():
+            schedule.run_pending()
+            time.sleep(0.05)
+    worker = threading.Thread(target=worker_loop, daemon=True)
+    worker.start()
+    time.sleep(1.5)
+    stop.set()
+    worker.join(timeout=2.0)
+    assert not worker.is_alive(), "worker did not exit cleanly"
+    assert mt[0] >= 1, f"mt-counter={mt[0]}"
+    schedule.clear()
+
     print("schedule: PASS")
 except Exception as e:
     print(f"schedule: FAIL: {e}")

--- a/tests/func/test_108_schedule.py
+++ b/tests/func/test_108_schedule.py
@@ -1,0 +1,17 @@
+"""Test: schedule"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import schedule, time
+    counter = [0]
+    def job():
+        counter[0] += 1
+    schedule.every(1).seconds.do(job)
+    time.sleep(1.1)
+    schedule.run_pending()
+    assert counter[0] >= 1, f"counter={counter[0]}"
+    schedule.clear()
+    print("schedule: PASS")
+except Exception as e:
+    print(f"schedule: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Ports `schedule` 1.2.2 by appending one pinned line to the existing pure-Python manifest and adding a smoke test in the upstream convention. The smoke exercises both the single-threaded scheduler path and (via the second commit) a `threading.RLock`-touching multi-threaded path.

Closes #112.

## Decisions

Inherits the resolved verdicts from the `port-srt` design:

- **Install pathway:** `requirements/site-packages-base.txt` + the existing `pip --target` flow driven by `.nanvix/z.py`. No vendoring, no `Modules/Setup.local`, no `.nanvix/schedule.py`, no `patches/schedule/`.
- **Acceptance bar:** a single-file `tests/func/test_NNN_<pkg>.py` smoke test in the upstream convention; upstream's pytest suite is not run.
- **Smoke shape:** the canonical `test_020_click.py` shape (module docstring, line-buffered stdout, single `try:` block, PASS/FAIL+exit-1).
- **Numbering:** `max+1` over `tests/func/`; no historical back-fill. Lands as `test_108_schedule.py`.
- **Bucket placement:** `# Core utilities` in `-base.txt`, alongside `tenacity`/`filelock` (coordination/utility libraries). Alphabetically inserted between `packaging==23.2` and `setuptools==75.8.0`. `doc/packages.md` updated to match.

## Threading note

The multi-threaded half is split into a separate commit (`88fe923`) so that a threading-primitive failure can be diagnostically isolated from the substantive landing commit (`1b8a238`) without rolling back the whole port. The smoke uses `threading.RLock()` explicitly so it serves as the canary for RLock availability on the Nanvix CPython port. No `nanvix/cpython` enablement issue was filed: local verification across all three deployment modes shows no `RLock`/`Lock`/`thread`/`deadlock` failure.

## Test plan

Per `nanvix-python/AGENTS.md`:

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=$MODE ./z setup; ./z build; ./z test
```

for `MODE` ∈ {`standalone`, `single-process`, `multi-process`}. All three produce `schedule: PASS`. CI exercises all four platform configs per `doc/contributing.md` step 5.

## Ramfs size increase

Measured on a clean tree per the standard protocol (standalone mode; `./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build` between baseline and post).

|                                   |   baseline |    with change | delta                      |
| --------------------------------- | ---------: | -------------: | -------------------------- |
| ramfs image (`nanvix_rootfs.img`) | 84,877,312 B | 84,938,752 B | **+61,440 B (+60.0 KiB)**  |
| stripped-sysroot content          | 56,584,032 B | 56,625,459 B | +41,427 B (+40.5 KiB)      |
| files in ramfs                    |      4,793 |          4,795 | +2                         |

New ramfs paths (diff of `.nanvix/manifests/sysroot-ramfs.txt`):

- `lib/python3.12/site-packages/schedule-1.2.2.dist-info/METADATA`
- `lib/python3.12/site-packages/schedule/__init__.pyc`

That is **+0.072 % of an 81.0 MiB image**.
