### PR TITLE
pluggy: add pluggy==1.6.0 to site-packages-base + smoke test

### DIFF
--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -4,6 +4,7 @@ filelock==3.20.0
 immutabledict
 ordered-set==4.1.0
 packaging==23.2
+pluggy==1.6.0
 schedule==1.2.2
 setuptools==75.8.0
 tenacity

--- a/tests/func/test_109_pluggy.py
+++ b/tests/func/test_109_pluggy.py
@@ -1,0 +1,26 @@
+"""Test: pluggy"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import pluggy
+    hookspec = pluggy.HookspecMarker("nanvix_smoke")
+    hookimpl = pluggy.HookimplMarker("nanvix_smoke")
+
+    class Spec:
+        @hookspec
+        def add(self, a, b): ...
+
+    class Impl:
+        @hookimpl
+        def add(self, a, b):
+            return a + b
+
+    pm = pluggy.PluginManager("nanvix_smoke")
+    pm.add_hookspecs(Spec)
+    pm.register(Impl())
+    results = pm.hook.add(a=2, b=3)
+    assert results == [5], results
+    print("pluggy: PASS")
+except Exception as e:
+    print(f"pluggy: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Ports `pluggy` 1.6.0 by appending one pinned line to the existing pure-Python manifest and adding a smoke test in the upstream convention. The smoke exercises the `HookspecMarker` / `HookimplMarker` / `PluginManager` round-trip path (which transitively exercises `inspect.signature`) and deliberately does **not** exercise `load_setuptools_entrypoints()` — see the caveat below.

Closes #95.

## Decisions

- **Install pathway:** `requirements/site-packages-base.txt` + the existing `pip --target` flow driven by `.nanvix/z.py`. No vendoring, no `Modules/Setup.local`, no `.nanvix/pluggy.py`, no `patches/pluggy/`.
- **Acceptance bar:** a single-file `tests/func/test_NNN_<pkg>.py` smoke test in the upstream convention; pluggy's upstream `testing/*.py` suite is not run (it requires pytest, which `pluggy` is the prerequisite for).
- **Smoke shape:** the canonical `test_020_click.py` shape (module docstring, line-buffered stdout, single `try:` block, PASS/FAIL+exit-1). Lands as `test_109_pluggy.py`.
- **Bucket placement:** `# Core utilities` in `-base.txt`, alongside `tenacity`/`filelock`/`packaging` (small standalone utility libraries; pluggy's runtime profile is zero `Requires-Dist`). Alphabetically inserted between `packaging==23.2` and `schedule==1.2.2`.
- **No `nanvix/cpython` enablement issue filed.** Positive recon on `inspect.signature` and `importlib.metadata` (both confirmed present and active in the 3.12.3 sysroot) plus a reactive failure stance: only file upstream if the smoke trips with a stdlib-surface signature, which it does not.

## Caveat: dist-info trim

`_create_stripped_sysroot()` in `.nanvix/z.py` removes `entry_points.txt` from `*.dist-info/` directories, so `pluggy.PluginManager.load_setuptools_entrypoints()` will silently return zero plugins on standalone-mode targets. The smoke routes around this by exercising the marker / register / dispatch path directly. Fixing the strip step (preserving `entry_points.txt`) is deferred — a future port that depends on entry-point discovery should drive that fix reactively.

## Test plan

Per `nanvix-python/AGENTS.md`:

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=$MODE ./z setup; ./z build; ./z test
```

for `MODE` ∈ {`standalone`, `single-process`, `multi-process`}. All three produce `pluggy: PASS`. CI exercises all four platform configs per `doc/contributing.md` step 5.

## Ramfs size increase

The ramfs grows by 114,688 bytes (+112.0 KiB, +0.135%) on standalone — see the table below.

Measured on a clean tree per the standard protocol (standalone mode; `./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build` between baseline and post).

|                                   |     baseline |   with change | delta                      |
| --------------------------------- | -----------: | ------------: | -------------------------- |
| ramfs image (`nanvix_rootfs.img`) | 84,938,752 B | 85,053,440 B  | **+114,688 B (+112.0 KiB)** |
| files in ramfs                    |        4,795 |         4,804 | +9                         |

New ramfs paths:

- `lib/python3.12/site-packages/pluggy-1.6.0.dist-info/METADATA`
- `lib/python3.12/site-packages/pluggy/__init__.pyc`
- `lib/python3.12/site-packages/pluggy/_callers.pyc`
- `lib/python3.12/site-packages/pluggy/_hooks.pyc`
- `lib/python3.12/site-packages/pluggy/_manager.pyc`
- `lib/python3.12/site-packages/pluggy/_result.pyc`
- `lib/python3.12/site-packages/pluggy/_tracing.pyc`
- `lib/python3.12/site-packages/pluggy/_version.pyc`
- `lib/python3.12/site-packages/pluggy/_warnings.pyc`

That is **+0.135 % of an 81.1 MiB image**.
