### PR TITLE
pytest: add pytest==9.0.3 to site-packages-base + smoke test

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -25,6 +25,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | immutabledict      | —       |
 | ordered-set        | 4.1.0   |
 | packaging          | 23.2    |
+| pluggy             | 1.6.0   |
 | schedule           | 1.2.2   |
 | setuptools         | 75.8.0  |
 | tenacity           | —       |

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -75,6 +75,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | spacy-loggers      | 1.0.5   |
 | wasabi             | 1.1.3   |
 | hypothesis         | 6.152.4 |
+| pytest             | 9.0.3   |
 | sortedcontainers   | 2.4.0   |
 | cycler             | 0.12.1  |
 | entrypoints        | 0.4     |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -74,6 +74,7 @@ wasabi==1.1.3
 
 # Testing
 hypothesis==6.152.4
+pytest==9.0.3
 sortedcontainers==2.4.0
 
 # Miscellaneous

--- a/tests/func/test_110_pytest.py
+++ b/tests/func/test_110_pytest.py
@@ -6,21 +6,21 @@ sys.stdout.reconfigure(line_buffering=True)
 try:
     import pytest
 
-    tmpdir = tempfile.mkdtemp()
-    pass_dir = os.path.join(tmpdir, "pass")
-    fail_dir = os.path.join(tmpdir, "fail")
-    os.mkdir(pass_dir)
-    os.mkdir(fail_dir)
-    with open(os.path.join(pass_dir, "test_pass.py"), "w") as f:
-        f.write("def test_ok():\n    assert 1 + 1 == 2\n")
-    with open(os.path.join(fail_dir, "test_fail.py"), "w") as f:
-        f.write("def test_bad():\n    assert 1 + 1 == 3\n")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pass_dir = os.path.join(tmpdir, "pass")
+        fail_dir = os.path.join(tmpdir, "fail")
+        os.mkdir(pass_dir)
+        os.mkdir(fail_dir)
+        with open(os.path.join(pass_dir, "test_pass.py"), "w") as f:
+            f.write("def test_ok():\n    assert 1 + 1 == 2\n")
+        with open(os.path.join(fail_dir, "test_fail.py"), "w") as f:
+            f.write("def test_bad():\n    assert 1 + 1 == 3\n")
 
-    rc_pass = pytest.main([pass_dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
-    assert rc_pass == pytest.ExitCode.OK, rc_pass
+        rc_pass = pytest.main([pass_dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
+        assert rc_pass == pytest.ExitCode.OK, rc_pass
 
-    rc_fail = pytest.main([fail_dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
-    assert rc_fail == pytest.ExitCode.TESTS_FAILED, rc_fail
+        rc_fail = pytest.main([fail_dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
+        assert rc_fail == pytest.ExitCode.TESTS_FAILED, rc_fail
 
     print("pytest: PASS")
 except Exception as e:

--- a/tests/func/test_110_pytest.py
+++ b/tests/func/test_110_pytest.py
@@ -1,0 +1,28 @@
+"""Test: pytest"""
+import os
+import sys
+import tempfile
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import pytest
+
+    tmpdir = tempfile.mkdtemp()
+    pass_dir = os.path.join(tmpdir, "pass")
+    fail_dir = os.path.join(tmpdir, "fail")
+    os.mkdir(pass_dir)
+    os.mkdir(fail_dir)
+    with open(os.path.join(pass_dir, "test_pass.py"), "w") as f:
+        f.write("def test_ok():\n    assert 1 + 1 == 2\n")
+    with open(os.path.join(fail_dir, "test_fail.py"), "w") as f:
+        f.write("def test_bad():\n    assert 1 + 1 == 3\n")
+
+    rc_pass = pytest.main([pass_dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
+    assert rc_pass == pytest.ExitCode.OK, rc_pass
+
+    rc_fail = pytest.main([fail_dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
+    assert rc_fail == pytest.ExitCode.TESTS_FAILED, rc_fail
+
+    print("pytest: PASS")
+except Exception as e:
+    print(f"pytest: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Closes #94.

## What

Ports `pytest==9.0.3` to the Nanvix Python distribution by appending it
to `requirements/site-packages-base.txt` (the existing pure-Python
manifest installed via `pip --target` during `./z build`) and adding a
smoke test at `tests/func/test_110_pytest.py` that exercises the
in-process `pytest.main([...])` collection + execution path against a
trivially-passing and a trivially-failing test pair.

Also back-fills the `pluggy==1.6.0` row that was missing from
`doc/packages.md` after #176.

The smoke invokes pytest with a fixed three-flag argv:

```
pytest.main([dir, "-p", "no:faulthandler", "-p", "no:logging", "-p", "no:cacheprovider", "--capture=sys"])
```

Each flag routes around a distinct session-configure path that hits a
Nanvix gap:

- `-p no:faulthandler` skips the `pytest_configure` `os.dup(stderr_fileno)`
  call in `_pytest/faulthandler.py:44`. `os.dup` is exported from the
  Nanvix syscall layer (so `HAVE_DUP=1` and `os.dup` exists in Python)
  but the syscall stub returns `ENOSYS`.
- `-p no:logging` skips the eager `open(os.devnull, "w")` in
  `_pytest/logging.py:668-675`. The standalone-mode ramfs has no `/dev`
  directory, so `os.devnull` opens raise `ENOENT`.
- `-p no:cacheprovider` skips the `.pytest_cache` directory creation
  during teardown, which hangs the VFS on `mkdirat` when the rootdir
  already exists.
- `--capture=sys` selects the pure-Python `SysCapture` path instead of
  the default `--capture=fd` mode, which calls `os.dup2` (also `ENOSYS`).

`pytest.main([...])` is used instead of `subprocess.run([sys.executable,
"-m", "pytest", ...])` because the Nanvix syscall layer stubs `fork`,
`execve`, and `waitpid` to `ENOSYS`, so any out-of-process invocation
would deadlock immediately.

## Why

`pytest` is the strategic payoff of the pure-Python porting umbrella:
once it runs on-target, subsequent ports can lean on each package's own
upstream test suite instead of hand-authored smoke probes. All four
runtime dependencies (`iniconfig`, `packaging`, `pluggy`, `pygments`)
are already vendored in `site-packages-base.txt`; the three
marker-gated deps (`colorama`, `exceptiongroup`, `tomli`) are skipped
under Linux/Python-3.12 wheel resolution at `pip install --target` time.

## Tests

- `./z distclean && ./z clean && NANVIX_DEPLOYMENT_MODE=standalone ./z setup && ./z build && ./z test`
  → `pytest: PASS`. Full functional suite: `Results: 105 passed, 0
  failed, 0 skipped`.
- The smoke runs `pytest.main(...)` twice — once against a one-test
  passing dir (asserts `ExitCode.OK`) and once against a one-test
  failing dir (asserts `ExitCode.TESTS_FAILED`) — staged under
  `tempfile.mkdtemp()`.

## Ramfs size increase

Measured on a clean tree, standalone mode, baseline = `feat/port-pytest`
with `requirements/`, `doc/`, and `tests/` reverted via `git stash`,
post = the change re-applied. Both builds run with the
`.nanvix-installed` sentinel and `.ramfs-built` marker removed to force
a fresh `pip --target` install and a fresh ramfs rebuild.

|                                   | baseline       | with change    | delta                        |
| --------------------------------- | -------------: | -------------: | ---------------------------- |
| ramfs image (`nanvix_rootfs.img`) | 85,053,440 B   | 87,465,984 B   | **+2,412,544 B (+2.30 MiB)** |
| stripped-sysroot content          | 56,699,960 B   | 58,307,956 B   | +1,607,996 B (+1.53 MiB)     |
| files in ramfs                    |        4,804   |        4,879   | +75                          |

New ramfs paths (75 entries) cluster under three top-level directories:

- `lib/python3.12/site-packages/_pytest/**/*.pyc` — pytest's internal
  package (53 files, including sub-packages `_code/`, `_io/`, `_py/`,
  `assertion/`, `config/`, `mark/`).
- `lib/python3.12/site-packages/pytest/{__init__,__main__}.pyc` — the
  public top-level package.
- `lib/python3.12/site-packages/py.pyc` — the back-compat shim for the
  legacy `py` library (vendored inside `_pytest/_py/` since pytest 8.4).
- `lib/python3.12/site-packages/pytest-9.0.3.dist-info/METADATA` — the
  surviving `dist-info` payload after `_create_stripped_sysroot()`'s
  trim step.

The +2.30 MiB image delta is **+2.84 % of an 81.2 MiB image**.

## Checklist

- [x] `pytest==9.0.3` pinned in `requirements/site-packages-base.txt`
      under the `# Testing` block, alphabetically between
      `hypothesis==6.152.4` and `sortedcontainers==2.4.0`.
- [x] `doc/packages.md` updated to list `pytest 9.0.3` and back-fill
      the missing `pluggy 1.6.0` row from #176.
- [x] Smoke at `tests/func/test_110_pytest.py` follows the canonical
      `tests/func/test_020_click.py` envelope (`try/except` →
      `print "pytest: PASS"` / `print f"pytest: FAIL: {e}"; sys.exit(1)`).
- [x] In-process `pytest.main([...])` only — no `subprocess.run` arm,
      no `load_setuptools_entrypoints()` arm.
- [x] Standalone gauntlet: `./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test` → 105 passed, 0 failed.
- [x] Ramfs delta measured on a clean tree.
