### PR TITLE
svgwrite: add svgwrite==1.4.3 + tests/func/test_110_svgwrite.py

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -114,6 +114,7 @@ Source: [`requirements/site-packages-extra.txt`](../requirements/site-packages-e
 | pylatex          | 1.4.2   |
 | PyPDF2           | 3.0.1   |
 | pypdf            | —       |
+| svgwrite         | 1.4.3   |
 | google-pasta     | 0.2.0   |
 | nltk             | —       |
 | python-dateutil  | 2.8.2   |

--- a/requirements/site-packages-extra.txt
+++ b/requirements/site-packages-extra.txt
@@ -29,6 +29,7 @@ pandoc==2.4
 pylatex==1.4.2
 PyPDF2==3.0.1
 pypdf
+svgwrite==1.4.3
 
 # Scientific and NLP
 google-pasta==0.2.0

--- a/tests/func/test_110_svgwrite.py
+++ b/tests/func/test_110_svgwrite.py
@@ -1,0 +1,19 @@
+"""Test: svgwrite"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import svgwrite
+    import xml.etree.ElementTree as ET
+    dwg = svgwrite.Drawing("smoke.svg", size=(100, 100))
+    dwg.add(dwg.circle(center=(50, 50), r=40, fill="red"))
+    dwg.add(dwg.path(d="M10 10 L90 90", stroke="black"))
+    xml = dwg.tostring()
+    root = ET.fromstring(xml)
+    assert root.tag.endswith("svg"), root.tag
+    tags = [child.tag for child in root]
+    assert any(t.endswith("circle") for t in tags), tags
+    assert any(t.endswith("path") for t in tags), tags
+    print("svgwrite: PASS")
+except Exception as e:
+    print(f"svgwrite: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Closes #109.

## What

Adds [`svgwrite==1.4.3`](https://pypi.org/project/svgwrite/) — a pure-Python
SVG document builder — to the standalone CPython port.

- `requirements/site-packages-extra.txt`: pinned `svgwrite==1.4.3` in the
  templating / document generation block.
- `doc/packages.md`: listed under the Extra Packages table.
- `tests/func/test_110_svgwrite.py`: smoke test that builds a `Drawing`
  with a `circle` and a `path`, calls `tostring()`, and round-trips the
  result through `xml.etree.ElementTree` to confirm well-formed SVG with
  the expected child elements.

## Why

svgwrite is a small, dependency-free pure-Python library used for
programmatic SVG generation. Its only stdlib needs are
`xml.etree.ElementTree`, `copy`, `re`, `io`, `base64`, and (for
`.svgz`) `gzip` — all available on the Nanvix CPython port. The smoke
test does not exercise `.svgz` so `gzip` availability is not on the
critical path.

## Tests

Full verify gate, standalone mode:

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

Result: `Results: 105 passed, 0 failed, 0 skipped` — including
`svgwrite: PASS`.

## Ramfs size increase

Measured per the protocol in the contributor PR template, both builds
under `NANVIX_DEPLOYMENT_MODE=standalone` with a `./z distclean` between
runs.

|                                   |       baseline |    with change | delta                       |
| --------------------------------- | -------------: | -------------: | --------------------------- |
| ramfs image (`nanvix_rootfs.img`) | 85,053,440 B   | 85,438,464 B   | **+385,024 B (+376.0 KiB)** |
| stripped-sysroot content          | 56,699,960 B   | 56,958,840 B   | +258,880 B (+252.8 KiB)     |
| files in ramfs                    |        4,804   |        4,837   | +33                         |

New ramfs paths (diff of `.nanvix/manifests/sysroot-ramfs.txt`):

- `lib/python3.12/site-packages/svgwrite-1.4.3.dist-info/METADATA`
- `lib/python3.12/site-packages/svgwrite/__init__.pyc`
- `lib/python3.12/site-packages/svgwrite/animate.pyc`
- `lib/python3.12/site-packages/svgwrite/base.pyc`
- `lib/python3.12/site-packages/svgwrite/container.pyc`
- `lib/python3.12/site-packages/svgwrite/data/__init__.pyc`
- `lib/python3.12/site-packages/svgwrite/data/colors.pyc`
- `lib/python3.12/site-packages/svgwrite/data/full11.pyc`
- `lib/python3.12/site-packages/svgwrite/data/pattern.pyc`
- `lib/python3.12/site-packages/svgwrite/data/svgparser.pyc`
- `lib/python3.12/site-packages/svgwrite/data/tiny12.pyc`
- `lib/python3.12/site-packages/svgwrite/data/typechecker.pyc`
- `lib/python3.12/site-packages/svgwrite/data/types.pyc`
- `lib/python3.12/site-packages/svgwrite/drawing.pyc`
- `lib/python3.12/site-packages/svgwrite/elementfactory.pyc`
- `lib/python3.12/site-packages/svgwrite/etree.pyc`
- `lib/python3.12/site-packages/svgwrite/extensions/__init__.pyc`
- `lib/python3.12/site-packages/svgwrite/extensions/inkscape.pyc`
- `lib/python3.12/site-packages/svgwrite/extensions/shapes.pyc`
- `lib/python3.12/site-packages/svgwrite/filters.pyc`
- `lib/python3.12/site-packages/svgwrite/gradients.pyc`
- `lib/python3.12/site-packages/svgwrite/image.pyc`
- `lib/python3.12/site-packages/svgwrite/masking.pyc`
- `lib/python3.12/site-packages/svgwrite/mixins.pyc`
- `lib/python3.12/site-packages/svgwrite/params.pyc`
- `lib/python3.12/site-packages/svgwrite/path.pyc`
- `lib/python3.12/site-packages/svgwrite/pattern.pyc`
- `lib/python3.12/site-packages/svgwrite/shapes.pyc`
- `lib/python3.12/site-packages/svgwrite/solidcolor.pyc`
- `lib/python3.12/site-packages/svgwrite/text.pyc`
- `lib/python3.12/site-packages/svgwrite/utils.pyc`
- `lib/python3.12/site-packages/svgwrite/validator2.pyc`
- `lib/python3.12/site-packages/svgwrite/version.pyc`

Image delta is +376 KiB, ~0.45 % of the 81.1 MiB ramfs image.
