### PR TITLE
feat: port markdownify

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -45,6 +45,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | idna               | 3.11    |
 | markdown           | —       |
 | markdown-it-py     | 4.0.0   |
+| markdownify        | —       |
 | MarkupSafe         | 2.1.5   |
 | mdurl              | 0.1.2   |
 | pygments           | —       |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -30,6 +30,7 @@ idna==3.11
 # Markup and rendering
 markdown
 markdown-it-py==4.0.0
+markdownify
 MarkupSafe==2.1.5
 mdurl==0.1.2
 pygments

--- a/tests/func/test_110_markdownify.py
+++ b/tests/func/test_110_markdownify.py
@@ -1,0 +1,20 @@
+"""Test: markdownify"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    from markdownify import markdownify as md
+    html = (
+        "<h1>Title</h1>"
+        "<p>See <a href=\"https://example.com\">example</a>.</p>"
+        "<ul><li>one</li><li>two</li></ul>"
+    )
+    # markdownify uses BeautifulSoup under the hood; the html.parser
+    # backend is the only one available on Nanvix (no lxml/html5lib).
+    out = md(html, heading_style="ATX")
+    assert "# Title" in out, out
+    assert "[example](https://example.com)" in out, out
+    assert "* one" in out and "* two" in out, out
+    print("markdownify: PASS")
+except Exception as e:
+    print(f"markdownify: FAIL: {e}")
+    sys.exit(1)

--- a/tests/func/test_112_markdownify.py
+++ b/tests/func/test_112_markdownify.py
@@ -8,8 +8,8 @@ try:
         "<p>See <a href=\"https://example.com\">example</a>.</p>"
         "<ul><li>one</li><li>two</li></ul>"
     )
-    # markdownify uses BeautifulSoup under the hood; the html.parser
-    # backend is the only one available on Nanvix (no lxml/html5lib).
+    # markdownify uses BeautifulSoup under the hood.
+    # This test validates the Markdown conversion result.
     out = md(html, heading_style="ATX")
     assert "# Title" in out, out
     assert "[example](https://example.com)" in out, out


### PR DESCRIPTION
Closes #105.

## What

Adds the `markdownify` HTML→Markdown converter to the standalone sysroot:

- `requirements/site-packages-base.txt`: insert `markdownify` in the
  "Markup and rendering" block (alphabetical between `markdown-it-py`
  and `MarkupSafe`).
- `doc/packages.md`: matching row in the same section.
- `tests/func/test_112_markdownify.py`: smoke test that imports
  `markdownify` and round-trips a small HTML snippet (heading, link,
  list) to Markdown, asserting the expected ATX/inline-link/bullet
  output.

`markdownify` drives BeautifulSoup, which on Nanvix falls back to
the stdlib `html.parser` (no `lxml`, no `html5lib` C deps). The
smoke test exercises that path implicitly; both `beautifulsoup4`
and `soupsieve` already ship in the sysroot.

## Tests

`./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test`
passes clean: 107 passed, 0 failed, 0 skipped, including the new
`markdownify: PASS` line.

## Ramfs size increase

Measured against `origin/main` at `86142f8` (post docx2txt / svgwrite
landings):

|                                   |     baseline |   with change | delta                       |
| --------------------------------- | -----------: | ------------: | --------------------------- |
| ramfs image (`nanvix_rootfs.img`) | 85,450,752 B | 85,520,384 B  | **+69,632 B (+68.0 KiB)**   |
| stripped-sysroot content          | 56,964,903 B | 57,012,580 B  | +47,677 B (+46.6 KiB)       |
| files in ramfs                    |        4,840 |         4,843 | +3                          |

New ramfs paths:

- `lib/python3.12/site-packages/markdownify/__init__.pyc`
- `lib/python3.12/site-packages/markdownify/main.pyc`
- `lib/python3.12/site-packages/markdownify-1.2.2.dist-info/METADATA`

That is +0.08 % of an 81.6 MiB image.

## Caveat

Only the stdlib `html.parser` backend is available on Nanvix; `lxml`
and `html5lib` are not. Edge-case fidelity and performance are lower
than the typical desktop install, which is the documented upstream
fallback behavior for BeautifulSoup. The smoke test uses inputs that
`html.parser` handles correctly.

## Checklist

- [x] `requirements/site-packages-base.txt` updated, alphabetical within block
- [x] `doc/packages.md` updated in the matching section
- [x] Smoke test added at `tests/func/test_112_markdownify.py`
- [x] Full verify gate green (107 passed)
- [x] Ramfs delta measured and reported
