### PR TITLE
docx2txt: add docx2txt==0.9 + tests/func/test_111_docx2txt.py

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -108,6 +108,7 @@ Source: [`requirements/site-packages-extra.txt`](../requirements/site-packages-e
 | msgpack          | —       |
 | pyyaml           | —       |
 | docutils         | —       |
+| docx2txt         | 0.9     |
 | fonttools        | 4.49.0  |
 | Jinja2           | —       |
 | pandoc           | 2.4     |

--- a/requirements/site-packages-extra.txt
+++ b/requirements/site-packages-extra.txt
@@ -23,6 +23,7 @@ pyyaml
 
 # Templating and document generation
 docutils
+docx2txt==0.9
 fonttools==4.49.0
 Jinja2
 pandoc==2.4

--- a/tests/func/test_111_docx2txt.py
+++ b/tests/func/test_111_docx2txt.py
@@ -1,0 +1,34 @@
+"""Test: docx2txt"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import io
+    import zipfile
+    import docx2txt
+
+    # Build a minimal in-memory .docx (a ZIP container with an OOXML
+    # word/document.xml part). Avoids shipping a binary fixture.
+    document_xml = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document xmlns:w='
+        '"http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+        '<w:body>'
+        '<w:p><w:r><w:t>hello</w:t></w:r></w:p>'
+        '<w:p><w:r><w:t>world</w:t><w:tab/><w:t>again</w:t></w:r></w:p>'
+        '</w:body>'
+        '</w:document>'
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("word/document.xml", document_xml)
+    buf.seek(0)
+
+    text = docx2txt.process(buf)
+    assert "hello" in text, text
+    assert "world" in text, text
+    assert "again" in text, text
+    assert "\t" in text, repr(text)
+    print("docx2txt: PASS")
+except Exception as e:
+    print(f"docx2txt: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Closes #106.

## What

Adds [`docx2txt==0.9`](https://pypi.org/project/docx2txt/) — a single-file
pure-Python `.docx` text extractor — to `requirements/site-packages-extra.txt`
under "Templating and document generation", with the matching
`doc/packages.md` row, and a smoke test at `tests/func/test_111_docx2txt.py`.

## Why

`docx2txt` is a small, dependency-free `.docx` reader (`zipfile` +
`xml.etree.ElementTree`). Both stdlib surfaces are already exercised by the
existing port (e.g. `python-pptx`, `openpyxl`, `et-xmlfile`), so this is a
pure additive port with no expected sharp edges.

## Tests

The smoke test builds a minimal OOXML `.docx` in memory with `zipfile`
(one `word/document.xml` part with two `<w:p>` paragraphs and a `<w:tab/>`),
hands the `BytesIO` to `docx2txt.process(...)`, and asserts that the
extracted text contains the expected runs and tab character. No on-disk
fixture is committed.

Verify gate:

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

passes — `Results: 105 passed, 0 failed, 0 skipped` — with `docx2txt: PASS`
in the output.

## Ramfs size increase

Measured on standalone mode, clean tree both sides:

|                                   |    baseline |  with change | delta                |
| --------------------------------- | ----------: | -----------: | -------------------- |
| ramfs image (`nanvix_rootfs.img`) | 85,053,440 B | 85,061,632 B | **+8,192 B (+8.0 KiB)** |
| stripped-sysroot content          | 56,699,960 B | 56,706,023 B | +6,063 B             |
| files in ramfs                    |       4,804 |        4,807 | +3                   |

New paths in `sysroot-ramfs.txt`:

- `lib/python3.12/site-packages/docx2txt/__init__.pyc`
- `lib/python3.12/site-packages/docx2txt/docx2txt.pyc`
- `lib/python3.12/site-packages/docx2txt-0.9.dist-info/METADATA`

That is ~0.01 % of an 81 MiB image.

## Checklist

- [x] Pinned addition to `requirements/site-packages-extra.txt`, alphabetical within section
- [x] Matching `doc/packages.md` row
- [x] Smoke test at `tests/func/test_111_docx2txt.py` (max+1 over `origin/main`)
- [x] Verify gate green (105 passed)
- [x] Ramfs delta measured and reported
