### PR TITLE
sniffio: port sniffio==1.3.1 (httpx closure step 1)

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -28,6 +28,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | pluggy             | 1.6.0   |
 | schedule           | 1.2.2   |
 | setuptools         | 75.8.0  |
+| sniffio            | 1.3.1   |
 | tenacity           | —       |
 | toolz              | 0.12.1  |
 | tqdm               | —       |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -7,6 +7,7 @@ packaging==23.2
 pluggy==1.6.0
 schedule==1.2.2
 setuptools==75.8.0
+sniffio==1.3.1
 tenacity
 toolz==0.12.1
 tqdm

--- a/tests/func/test_113_sniffio.py
+++ b/tests/func/test_113_sniffio.py
@@ -1,0 +1,35 @@
+"""Test: sniffio"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import sniffio
+
+    # Outside any async context: AsyncLibraryNotFoundError.
+    try:
+        sniffio.current_async_library()
+    except sniffio.AsyncLibraryNotFoundError:
+        pass
+    else:
+        raise AssertionError("expected AsyncLibraryNotFoundError outside async context")
+
+    # Public contextvar override: detection round-trip without an event loop.
+    token = sniffio.current_async_library_cvar.set("asyncio")
+    try:
+        assert sniffio.current_async_library() == "asyncio"
+    finally:
+        sniffio.current_async_library_cvar.reset(token)
+
+    # After reset: back to AsyncLibraryNotFoundError.
+    try:
+        sniffio.current_async_library()
+    except sniffio.AsyncLibraryNotFoundError:
+        pass
+    else:
+        raise AssertionError("contextvar reset did not clear detection")
+
+    print("sniffio: PASS")
+except Exception as e:
+    import traceback
+    tb = traceback.format_exc().replace("\n", " | ")
+    print(f"sniffio: FAIL: {tb}")
+    sys.exit(1)


### PR DESCRIPTION
Closes part of nanvix/nanvix-python#131. Step 1 of the `httpx`
pure-Python closure (sniffio → anyio → h11 → httpcore → httpx).

## What

Adds the [`sniffio`](https://pypi.org/project/sniffio/) (1.3.1)
async-library detector to the Nanvix CPython port:

- Appends `sniffio==1.3.1` to `requirements/site-packages-base.txt`
  (alphabetical within the **Networking and async support** block).
- Adds the matching `sniffio 1.3.1` row to `doc/packages.md` under
  `## Base Packages` → `### Networking and async support`.
- Adds `tests/func/test_113_sniffio.py` — a single-file smoke test in
  the canonical `test_NNN_<pkg>.py` shape. Three checks: detection
  outside any async context raises `AsyncLibraryNotFoundError`, a
  `current_async_library_cvar` round-trip resolves correctly, and
  the contextvar reset restores the not-found error.

`sniffio` itself is a leaf dependency in this closure (no upstream
deps); it is included primarily because both `anyio` and `httpx`
declare it as a runtime requirement.

## Why

`sniffio` is upstream Tier-2: pure Python, ~6 KiB of source, no
runtime deps, `py3-none-any` wheel. Its only stdlib touchpoints are
`contextvars`, `sys`, and `threading` — all enabled on Nanvix CPython.

## Decisions

- **Sync-only smoke** per the closure umbrella's standing decision.
  `asyncio.run()` is nonfunctional on Nanvix standalone (`socket.socketpair()`
  returns `OSError: [Errno 107]` ENOTCONN at event-loop init). The smoke
  exercises only the contextvar override path — sufficient to prove the
  package's surface area is wired correctly without depending on
  asyncio. See the closure-level note on this gap.
- **Bucket: `-base`.** Tiny package, no data payload, network-stack
  utility — fits the same bucket as `idna`, `certifi`.
- **Numbering.** `NNN = 113` chosen as `max+1` over `tests/func/`
  (previous high watermark on `origin/main`: `test_112_markdownify.py`).

## Test plan

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

| MODE       | Result                       | sniffio |
| ---------- | ---------------------------- | ------- |
| standalone | 109 passed, 0 failed         | PASS    |

CI exercises the full platform matrix per `doc/contributing.md`.

## Diff scope

- `requirements/site-packages-base.txt` — +1 line.
- `doc/packages.md` — +1 row.
- `tests/func/test_113_sniffio.py` — new file, 35 lines.

No edits to `.nanvix/`, `patches/`, `Modules/Setup.local`, or any
other manifest.

## Ramfs size increase

Measured on a clean tree (standalone mode), `distclean` between
runs. Baseline is `origin/main`.

|                                   |       baseline |    with `sniffio` | delta                        |
| --------------------------------- | -------------: | ----------------: | ---------------------------- |
| ramfs image (`nanvix_rootfs.img`) |   87,932,928 B |      87,949,312 B | **+16,384 B (+16.0 KiB)**    |
| stripped-sysroot content          |   58,620,576 B |      58,632,190 B | +11,614 B (+11.3 KiB)        |
| files in ramfs                    |          4,918 |             4,924 | +6                           |

This is also the cumulative delta for the whole stack at this point
(sniffio is the bottom of the closure stack).

New ramfs paths (excerpt of the manifest diff):

- `lib/python3.12/site-packages/sniffio-1.3.1.dist-info/METADATA`
- `lib/python3.12/site-packages/sniffio/__init__.pyc`
- `lib/python3.12/site-packages/sniffio/_impl.pyc`
- `lib/python3.12/site-packages/sniffio/_version.pyc`
- `lib/python3.12/site-packages/sniffio/_tests/__init__.pyc`
- `lib/python3.12/site-packages/sniffio/_tests/test_sniffio.pyc`

## Stacking

This PR is the **base** of the httpx closure stack:

```
main
 └── #184 sniffio        ← you are here
      └── #185 anyio
           └── #187 h11
                └── #188 httpcore
                     └── feat/port-httpx (draft)
```

Review and merge bottom-up. Each subsequent PR retargets to the
previous one in the stack so the diff view shows only that step's
changes.

## Checklist

- [x] Diff scope matches the design's Files-changed table
- [x] Smoke test follows the `test_NNN_<pkg>.py` convention
- [x] `sniffio: PASS` verified locally on `standalone`
- [x] No `.nanvix/` / `patches/` / `Modules/Setup.local` edits
- [x] Ramfs size delta measured (see above)
- [x] `doc/packages.md` updated
- [x] Closure step 1 of 4
