### PR TITLE
anyio: port anyio==4.13.0 (httpx closure step 2)

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -39,6 +39,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | pyparsing          | 3.1.1   |
 | typing-extensions  | 4.15.0  |
 | typing-inspection  | 0.4.2   |
+| anyio              | 4.13.0  |
 | certifi            | —       |
 | charset-normalizer | 3.4.4   |
 | cloudpathlib       | 0.23.0  |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -22,6 +22,7 @@ typing-extensions==4.15.0
 typing-inspection==0.4.2
 
 # Networking and I/O
+anyio==4.13.0
 certifi
 charset-normalizer==3.4.4
 cloudpathlib==0.23.0

--- a/tests/func/test_114_anyio.py
+++ b/tests/func/test_114_anyio.py
@@ -1,0 +1,21 @@
+"""Test: anyio"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import anyio
+    from importlib.metadata import version as _v
+    av = _v("anyio")
+    assert isinstance(av, str) and av, av
+
+    # Pure-sync surface: anyio.Path wraps pathlib.PurePath without touching
+    # any async backend machinery. MUST NOT call anyio.run() — asyncio is
+    # nonfunctional on Nanvix standalone (socket.socketpair ENOTCONN).
+    p = anyio.Path("/tmp") / "anyio-smoke.txt"
+    assert p.name == "anyio-smoke.txt", p.name
+    assert str(p.parent) == "/tmp", p.parent
+    assert p.suffix == ".txt", p.suffix
+
+    print(f"anyio: PASS ({av})")
+except Exception as e:
+    print(f"anyio: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Part of nanvix/nanvix-python#131. Step 2 of the `httpx` pure-Python
closure (sniffio → **anyio** → h11 → httpcore → httpx).

**Stacked on #184.** Review #184 first.

## What

Adds [`anyio`](https://pypi.org/project/anyio/) (4.13.0) to the
Nanvix CPython port:

- Appends `anyio==4.13.0` to `requirements/site-packages-base.txt`
  (alphabetical within the **Networking and async support** block).
- Adds the matching `anyio 4.13.0` row to `doc/packages.md` under
  `## Base Packages` → `### Networking and async support`.
- Adds `tests/func/test_114_anyio.py` — a single-file smoke test
  exercising only sync surfaces (`anyio.Path` plus `__version__`).

## Why

`anyio` is a runtime dependency of `httpcore` and `httpx`. Pure
Python, `py3-none-any` wheel. Depends on `sniffio` (#184) and `idna`
(already shipped).

The `trio` backend is not installed; only the `asyncio` backend
ships, and the `asyncio` backend is dormant on Nanvix per the
closure-level finding (`socket.socketpair()` ENOTCONN). The package
is required at import time by downstream `httpx`/`httpcore` code
paths; the asyncio surfaces it exposes are inert until the kernel
gap is closed.

## Decisions

- **Sync-only smoke.** Per the closure umbrella's standing decision,
  the smoke MUST NOT call `anyio.run()` or any backend machinery.
  `anyio.Path` is a pure-sync `pathlib.Path` wrapper and adequate
  to prove the package imports and its top-level surface is wired.
- **No `trio` backend.** `trio` is out of scope for the entire
  closure.
- **Bucket: `-base`.** anyio is a runtime dep of two other base
  packages in this closure.
- **Numbering.** `NNN = 114` chosen as `max+1` over `origin/main`
  + `feat/port-sniffio` (previous high watermark in the stack:
  `test_113_sniffio.py`).

## Test plan

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

| MODE       | Result                       | anyio |
| ---------- | ---------------------------- | ----- |
| standalone | 110 passed, 0 failed         | PASS  |

## Diff scope

- `requirements/site-packages-base.txt` — +1 line.
- `doc/packages.md` — +1 row.
- `tests/func/test_114_anyio.py` — new file, 21 lines.

## Ramfs size increase

Measured on a clean tree (standalone mode), `distclean` between
runs. Two baselines reported: immediate (vs `feat/port-sniffio`,
the stacked base) and cumulative (vs `origin/main`).

|                                   | sniffio base   | with `anyio`   | delta vs sniffio              |
| --------------------------------- | -------------: | -------------: | ----------------------------- |
| ramfs image (`nanvix_rootfs.img`) |   87,949,312 B |   88,920,064 B | **+970,752 B (+948.0 KiB)**   |
| stripped-sysroot content          |   58,632,190 B |   59,279,576 B | +647,386 B (+632.2 KiB)       |
| files in ramfs                    |          4,924 |          4,967 | +43                           |

Cumulative delta from `origin/main` through this PR:

|                                   |  origin/main   | sniffio + anyio | cumulative delta              |
| --------------------------------- | -------------: | --------------: | ----------------------------- |
| ramfs image                       |   87,932,928 B |    88,920,064 B | **+987,136 B (+964.0 KiB)**   |
| files in ramfs                    |          4,918 |           4,967 | +49                           |

New ramfs paths from this PR (excerpt; full list in the manifest
diff):

- `lib/python3.12/site-packages/anyio-4.13.0.dist-info/METADATA`
- `lib/python3.12/site-packages/anyio/__init__.pyc`
- `lib/python3.12/site-packages/anyio/_backends/{__init__,_asyncio,_trio}.pyc`
- `lib/python3.12/site-packages/anyio/_core/{__init__,_asyncio_selector_thread,_contextmanagers,_eventloop,_exceptions,_fileio,_resources,_signals,_sockets,_streams,_subprocesses,_synchronization,_tasks,_tempfile,_testing,_typedattr}.pyc`
- `lib/python3.12/site-packages/anyio/abc/{__init__,_eventloop,_resources,_sockets,_streams,_subprocesses,_tasks,_testing}.pyc`
- `lib/python3.12/site-packages/anyio/streams/{__init__,buffered,file,memory,stapled,text,tls}.pyc`
- `lib/python3.12/site-packages/anyio/{from_thread,functools,lowlevel,pytest_plugin,to_interpreter,to_process,to_thread}.pyc`

The `_backends/_trio.pyc` and async-machinery `.pyc` files ship
deliberately — they are part of the standard `anyio` install and
the smoke does not exercise them. They become live once the asyncio
gap is closed; today they are dormant payload.

## Stacking

```
main
 └── #184 sniffio
      └── #185 anyio          ← you are here
           └── #187 h11
                └── #188 httpcore
                     └── feat/port-httpx (draft)
```

## Checklist

- [x] Diff scope matches the design's Files-changed table
- [x] Smoke test follows the `test_NNN_<pkg>.py` convention
- [x] `anyio: PASS` verified locally on `standalone`
- [x] No `.nanvix/` / `patches/` / `Modules/Setup.local` edits
- [x] Ramfs size delta measured (see above)
- [x] `doc/packages.md` updated
- [x] Closure step 2 of 4
