### PR TITLE
fix(ci): include kernel.elf in Windows release zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,9 +229,10 @@ jobs:
           mkdir -p nanvix-win-extract
           unzip -q "$WINZIP" -d nanvix-win-extract
 
-          # Replace Linux host binary with Windows host binary
+          # Replace Linux host binaries with Windows host binaries
           rm -f "$DIST_DIR/bin/nanvixd.elf"
           cp nanvix-win-extract/nanvixd.exe "$DIST_DIR/bin/nanvixd.exe"
+          cp nanvix-win-extract/kernel.elf "$DIST_DIR/bin/kernel.elf"
 
           # Create the Windows zip
           ZIP_NAME="${DIR_NAME}.zip"


### PR DESCRIPTION
## Problem

The Windows release zip produced by the \windows-release\ CI job hangs after printing output. The local build exits cleanly.

## Root Cause

The \windows-release\ job extracts the Linux \	ar.bz2\ artifact and replaces \
anvixd.elf\ with \
anvixd.exe\ from the Nanvix Windows release. However, it leaves the **Linux \kernel.elf\** (1,536,532 bytes) in place instead of using the **Windows \kernel.elf\** (1,544,724 bytes) from the Nanvix Windows release.

The mismatched kernel causes nanvixd.exe to hang after execution completes.

## Fix

Copy \kernel.elf\ from the Nanvix Windows release alongside \
anvixd.exe\.

## Validation

- Local build with correct kernel.elf: prints \42\ and exits cleanly
- Release with Linux kernel.elf: prints \42\ but hangs indefinitely
- SHA256 confirmed: local kernel matches Nanvix Windows release kernel