### PR TITLE
h11: add h11==0.16.0 + smoke test

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -44,6 +44,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | charset-normalizer | 3.4.4   |
 | cloudpathlib       | 0.23.0  |
 | fsspec             | —       |
+| h11                | 0.16.0  |
 | idna               | 3.11    |
 | markdown           | —       |
 | markdown-it-py     | 4.0.0   |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -27,6 +27,7 @@ certifi
 charset-normalizer==3.4.4
 cloudpathlib==0.23.0
 fsspec
+h11==0.16.0
 idna==3.11
 
 # Markup and rendering

--- a/tests/func/test_115_h11.py
+++ b/tests/func/test_115_h11.py
@@ -1,0 +1,50 @@
+"""Test: h11"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import h11
+
+    # In-memory HTTP/1.1 round-trip via the sans-I/O state machine.
+    client = h11.Connection(our_role=h11.CLIENT)
+    server = h11.Connection(our_role=h11.SERVER)
+
+    # Client sends a request + end-of-message.
+    req = h11.Request(
+        method="GET",
+        target="/hello",
+        headers=[("Host", "example.com"), ("Connection", "close")],
+    )
+    data = client.send(req) + client.send(h11.EndOfMessage())
+    assert data.startswith(b"GET /hello HTTP/1.1\r\n")
+
+    # Server parses the request.
+    server.receive_data(data)
+    parsed_req = server.next_event()
+    assert isinstance(parsed_req, h11.Request)
+    assert parsed_req.method == b"GET"
+    assert parsed_req.target == b"/hello"
+    assert isinstance(server.next_event(), h11.EndOfMessage)
+
+    # Server sends a response with a small body.
+    body = b"hi"
+    resp = h11.Response(
+        status_code=200,
+        headers=[("Content-Length", str(len(body))), ("Connection", "close")],
+    )
+    out = server.send(resp) + server.send(h11.Data(data=body)) + server.send(h11.EndOfMessage())
+    assert b"HTTP/1.1 200" in out
+
+    # Client parses the response.
+    client.receive_data(out)
+    parsed_resp = client.next_event()
+    assert isinstance(parsed_resp, h11.Response)
+    assert parsed_resp.status_code == 200
+    parsed_data = client.next_event()
+    assert isinstance(parsed_data, h11.Data)
+    assert parsed_data.data == body
+    assert isinstance(client.next_event(), h11.EndOfMessage)
+
+    print("h11: PASS")
+except Exception as e:
+    print(f"h11: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Part of nanvix/nanvix-python#131. Step 3a of the `httpx` pure-Python
closure (sniffio → anyio → **h11** → httpcore → httpx).

**Stacked on #185.** Review #184 → #185 → #187 in order.

## What

Adds [`h11`](https://pypi.org/project/h11/) (0.16.0) to the Nanvix
CPython port:

- Appends `h11==0.16.0` to `requirements/site-packages-base.txt`
  (alphabetical within the **Networking and async support** block).
- Adds the matching `h11 0.16.0` row to `doc/packages.md` under
  `## Base Packages` → `### Networking and async support`.
- Adds `tests/func/test_115_h11.py` — a single-file smoke test that
  drives a full client→server→client round-trip purely in-memory
  (no sockets), verifying the state-machine produces and parses
  Request / EndOfMessage / Response / Data / EndOfMessage events.

## Why

`h11` is the HTTP/1.1 protocol state-machine that `httpcore` (#188)
delegates wire-protocol parsing to. Pure Python, no runtime deps,
`py3-none-any` wheel. Stdlib touchpoints: `re`, `collections`, `enum`.

Although `h11` has no code-level dependency on `anyio` or `sniffio`,
it is stacked here so reviewers can land the closure as a single
linear sequence and so `httpcore` (#188) can target a base that
already contains both of its closure-mate dependencies (`anyio`
and `h11`).

## Decisions

- **In-memory smoke, no sockets.** `h11`'s public API is socket-free
  by design — bytes in, events out. The smoke exercises Connection
  on both client and server roles, asserts the seven event types
  the round-trip produces, and prints the standard `h11: PASS`
  marker.
- **Bucket: `-base`.** h11 is a runtime dep of httpcore in the
  same bucket.
- **Numbering.** `NNN = 115` chosen as `max+1` over the stack at
  this point (previous high watermark: `test_114_anyio.py`).

## Test plan

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

| MODE       | Result                       | h11  |
| ---------- | ---------------------------- | ---- |
| standalone | 111 passed, 0 failed         | PASS |

## Diff scope

- `requirements/site-packages-base.txt` — +1 line.
- `doc/packages.md` — +1 row.
- `tests/func/test_115_h11.py` — new file, 50 lines.

## Ramfs size increase

Measured on a clean tree (standalone mode), `distclean` between
runs. Two baselines reported: immediate (vs `feat/port-anyio`,
the stacked base) and cumulative (vs `origin/main`).

|                                   |    anyio base  |    with `h11`  | delta vs anyio                |
| --------------------------------- | -------------: | -------------: | ----------------------------- |
| ramfs image (`nanvix_rootfs.img`) |   88,920,064 B |   89,055,232 B | **+135,168 B (+132.0 KiB)**   |
| stripped-sysroot content          |   59,279,576 B |   59,368,679 B | +89,103 B (+87.0 KiB)         |
| files in ramfs                    |          4,967 |          4,979 | +12                           |

Cumulative delta from `origin/main` through this PR:

|                                   |  origin/main   | sniffio+anyio+h11 | cumulative delta            |
| --------------------------------- | -------------: | ----------------: | --------------------------- |
| ramfs image                       |   87,932,928 B |      89,055,232 B | **+1,122,304 B (+1.07 MiB)**|
| files in ramfs                    |          4,918 |             4,979 | +61                         |

New ramfs paths from this PR:

- `lib/python3.12/site-packages/h11-0.16.0.dist-info/METADATA`
- `lib/python3.12/site-packages/h11/__init__.pyc`
- `lib/python3.12/site-packages/h11/_abnf.pyc`
- `lib/python3.12/site-packages/h11/_connection.pyc`
- `lib/python3.12/site-packages/h11/_events.pyc`
- `lib/python3.12/site-packages/h11/_headers.pyc`
- `lib/python3.12/site-packages/h11/_readers.pyc`
- `lib/python3.12/site-packages/h11/_receivebuffer.pyc`
- `lib/python3.12/site-packages/h11/_state.pyc`
- `lib/python3.12/site-packages/h11/_util.pyc`
- `lib/python3.12/site-packages/h11/_version.pyc`
- `lib/python3.12/site-packages/h11/_writers.pyc`

## Stacking

```
main
 └── #184 sniffio
      └── #185 anyio
           └── #187 h11             ← you are here
                └── #188 httpcore
                     └── feat/port-httpx (draft)
```

## Checklist

- [x] Diff scope matches the design's Files-changed table
- [x] Smoke test follows the `test_NNN_<pkg>.py` convention
- [x] `h11: PASS` verified locally on `standalone`
- [x] No `.nanvix/` / `patches/` / `Modules/Setup.local` edits
- [x] Ramfs size delta measured (see above)
- [x] `doc/packages.md` updated
- [x] Closure step 3a of 4
