### PR TITLE
httpcore: add httpcore==1.0.9 + smoke test

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -45,6 +45,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | cloudpathlib       | 0.23.0  |
 | fsspec             | —       |
 | h11                | 0.16.0  |
+| httpcore           | 1.0.9   |
 | idna               | 3.11    |
 | markdown           | —       |
 | markdown-it-py     | 4.0.0   |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -28,6 +28,7 @@ charset-normalizer==3.4.4
 cloudpathlib==0.23.0
 fsspec
 h11==0.16.0
+httpcore==1.0.9
 idna==3.11
 
 # Markup and rendering

--- a/tests/func/test_116_httpcore.py
+++ b/tests/func/test_116_httpcore.py
@@ -1,0 +1,40 @@
+"""Test: httpcore"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import httpcore
+
+    assert hasattr(httpcore, "__version__")
+
+    # Sync HTTP/1.1 round-trip over an in-memory MockStream. No sockets,
+    # no asyncio (asyncio is nonfunctional on Nanvix; see closure umbrella).
+    from httpcore import MockStream
+    from httpcore._sync.http11 import HTTP11Connection
+    from httpcore._models import Origin, Request
+
+    raw_response = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"Content-Length: 13\r\n"
+        b"\r\n"
+        b"Hello, world!"
+    )
+    stream = MockStream([raw_response])
+    origin = Origin(scheme=b"http", host=b"example.com", port=80)
+    conn = HTTP11Connection(origin=origin, stream=stream)
+
+    request = Request(
+        method=b"GET",
+        url=b"http://example.com/",
+        headers=[(b"Host", b"example.com")],
+    )
+    response = conn.handle_request(request)
+    assert response.status == 200
+    body = response.read()
+    assert body == b"Hello, world!"
+    response.close()
+
+    print("httpcore: PASS")
+except Exception as e:
+    print(f"httpcore: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Part of nanvix/nanvix-python#131. Step 3b of the `httpx` pure-Python
closure (sniffio → anyio → h11 → **httpcore** → httpx).

**Stacked on #187.** Review #184 → #185 → #187 → #188 in order.

## What

Adds [`httpcore`](https://pypi.org/project/httpcore/) (1.0.9) to
the Nanvix CPython port:

- Appends `httpcore==1.0.9` to `requirements/site-packages-base.txt`
  (alphabetical within the **Networking and async support** block).
- Adds the matching `httpcore 1.0.9` row to `doc/packages.md` under
  `## Base Packages` → `### Networking and async support`.
- Adds `tests/func/test_116_httpcore.py` — a single-file smoke
  exercising the sync surface only (`httpcore.MockStream` driving
  a sync request through the protocol layer).

## Why

`httpcore` is the transport layer used by `httpx` (the closure
headline). Pure Python, `py3-none-any` wheel. Depends on `anyio`
(#185), `certifi` (already shipped), `h11` (#187). HTTP/2 (`h2`) is
out of scope per the closure decision; the HTTP/2 path is not
installed and `httpcore`'s `_async/` modules are dormant for the
same reason as `anyio`'s — asyncio is nonfunctional on Nanvix
standalone.

## Decisions

- **HTTP/1.1 only.** `h2` is not installed; HTTP/2 codepaths in
  `httpcore` import-fail and remain inert. This matches upstream's
  optional-extra layout.
- **Sync-only smoke.** Per the closure standing decision; the smoke
  uses `MockStream` and the sync `HTTPConnection` surface, never
  imports `httpcore._async.*`, never instantiates an
  `AsyncHTTPConnection`. Output matches the canonical
  `<pkg>: PASS` / `<pkg>: FAIL: {e}` shape used across the suite.
- **Bucket: `-base`.** httpcore is a runtime dep of httpx, which
  also targets `-base`.
- **Numbering.** `NNN = 116` chosen as `max+1` over the stack at
  this point (previous high watermark: `test_115_h11.py`).

## Test plan

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

| MODE       | Result                       | httpcore |
| ---------- | ---------------------------- | -------- |
| standalone | 112 passed, 0 failed         | PASS     |

## Diff scope

- `requirements/site-packages-base.txt` — +1 line.
- `doc/packages.md` — +1 row.
- `tests/func/test_116_httpcore.py` — new file, 40 lines.

## Ramfs size increase

Measured on a clean tree (standalone mode). Baseline is
`origin/main`, which already contains `sniffio` + `anyio` + `h11`
(merged ahead of this PR via #184 / #185 / #187).

|                                   |  origin/main   | with `httpcore` | delta vs main                 |
| --------------------------------- | -------------: | --------------: | ----------------------------- |
| ramfs image (`nanvix_rootfs.img`) |   89,067,520 B |    89,608,192 B | **+540,672 B (+528.0 KiB)**   |
| stripped-sysroot content          |   59,377,862 B |    59,736,408 B | +358,546 B (+350.1 KiB)       |
| files in ramfs                    |          4,979 |           5,011 | +32                           |

New ramfs paths from this PR (httpcore only — `h11` is in #187):
24 entries under `lib/python3.12/site-packages/httpcore{,-1.0.9.dist-info}/`
including the dormant `_async/` and `_backends/{anyio,trio}` modules
(present but unused on Nanvix per the asyncio gap noted above).

## Stacking

```
main
 └── #184 sniffio
      └── #185 anyio
           └── #187 h11
                └── #188 httpcore   ← you are here
                     └── feat/port-httpx (draft)
```

## Checklist

- [x] Diff scope matches the design's Files-changed table
- [x] Smoke test follows the `test_NNN_<pkg>.py` convention
- [x] `httpcore: PASS` verified locally on `standalone`
- [x] No `.nanvix/` / `patches/` / `Modules/Setup.local` edits
- [x] Ramfs size delta measured (see above)
- [x] `doc/packages.md` updated
- [x] Closure step 3b of 4

