### PR TITLE
httpx: port httpx==0.28.1 (httpx closure step 4, closes #131)

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -45,6 +45,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | cloudpathlib       | 0.23.0  |
 | fsspec             | —       |
 | h11                | 0.16.0  |
+| httpcore           | 1.0.9   |
 | idna               | 3.11    |
 | markdown           | —       |
 | markdown-it-py     | 4.0.0   |

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -46,6 +46,7 @@ Source: [`requirements/site-packages-base.txt`](../requirements/site-packages-ba
 | fsspec             | —       |
 | h11                | 0.16.0  |
 | httpcore           | 1.0.9   |
+| httpx              | 0.28.1  |
 | idna               | 3.11    |
 | markdown           | —       |
 | markdown-it-py     | 4.0.0   |

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -29,6 +29,7 @@ cloudpathlib==0.23.0
 fsspec
 h11==0.16.0
 httpcore==1.0.9
+httpx==0.28.1
 idna==3.11
 
 # Markup and rendering

--- a/requirements/site-packages-base.txt
+++ b/requirements/site-packages-base.txt
@@ -28,6 +28,7 @@ charset-normalizer==3.4.4
 cloudpathlib==0.23.0
 fsspec
 h11==0.16.0
+httpcore==1.0.9
 idna==3.11
 
 # Markup and rendering

--- a/tests/func/test_116_httpcore.py
+++ b/tests/func/test_116_httpcore.py
@@ -1,0 +1,40 @@
+"""Test: httpcore"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import httpcore
+
+    assert hasattr(httpcore, "__version__")
+
+    # Sync HTTP/1.1 round-trip over an in-memory MockStream. No sockets,
+    # no asyncio (asyncio is nonfunctional on Nanvix; see closure umbrella).
+    from httpcore import MockStream
+    from httpcore._sync.http11 import HTTP11Connection
+    from httpcore._models import Origin, Request
+
+    raw_response = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"Content-Length: 13\r\n"
+        b"\r\n"
+        b"Hello, world!"
+    )
+    stream = MockStream([raw_response])
+    origin = Origin(scheme=b"http", host=b"example.com", port=80)
+    conn = HTTP11Connection(origin=origin, stream=stream)
+
+    request = Request(
+        method=b"GET",
+        url=b"http://example.com/",
+        headers=[(b"Host", b"example.com")],
+    )
+    response = conn.handle_request(request)
+    assert response.status == 200
+    body = response.read()
+    assert body == b"Hello, world!"
+    response.close()
+
+    print("httpcore: PASS")
+except Exception as e:
+    print(f"httpcore: FAIL: {e}")
+    sys.exit(1)

--- a/tests/func/test_117_httpx.py
+++ b/tests/func/test_117_httpx.py
@@ -1,0 +1,30 @@
+"""Test: httpx"""
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+try:
+    import httpx
+
+    assert hasattr(httpx, "__version__")
+
+    # Sync GET round-trip via MockTransport. No sockets, no asyncio
+    # (asyncio is nonfunctional on Nanvix; see closure umbrella).
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert str(request.url) == "http://example.com/"
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "text/plain"},
+            text="Hello, world!",
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        response = client.get("http://example.com/")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/plain"
+        assert response.text == "Hello, world!"
+
+    print("httpx: PASS")
+except Exception as e:
+    print(f"httpx: FAIL: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Closes #131. Final step (4 of 4) of the `httpx` pure-Python closure
(sniffio → anyio → h11 → httpcore → **httpx**).

**Stacked on #188.** Review #184 → #185 → #187 → #188 → this PR in
order.

## What

Adds [`httpx`](https://pypi.org/project/httpx/) (0.28.1) to the
Nanvix CPython port:

- Appends `httpx==0.28.1` to `requirements/site-packages-base.txt`
  (alphabetical within the **Networking and async support** block).
- Adds the matching `httpx 0.28.1` row to `doc/packages.md` under
  `## Base Packages` → `### Networking and async support`.
- Adds `tests/func/test_117_httpx.py` — a single-file smoke that
  drives a sync `httpx.Client` over `httpx.MockTransport`, performs
  a `GET /` round-trip, and asserts on status, body, and request
  echoing.

## Why

`httpx` is the closure headline (upstream issue #131). Pure Python,
`py3-none-any` wheel. Runtime deps: `httpcore` (#188), `certifi`
(already shipped), `idna` (already shipped), `anyio` (#185). All
of those land in the stack ahead of this PR, so this PR's diff is
just the package itself plus the smoke.

## Decisions

- **Sync-only smoke** with `MockTransport`. Per the closure
  standing decision, the smoke MUST NOT touch `httpx.AsyncClient`
  and MUST NOT issue live HTTP. `MockTransport` keeps the smoke
  hermetic and proves the request/response object machinery — the
  actual port acceptance bar.
- **HTTP/1.1 only** transitively (via `httpcore` decision).
- **Bucket: `-base`.** Matches the rest of the closure.
- **Numbering.** `NNN = 117` chosen as `max+1` over the stack at
  this point (previous high watermark: `test_116_httpcore.py`).

## Test plan

```
./z distclean; ./z clean; NANVIX_DEPLOYMENT_MODE=standalone ./z setup; ./z build; ./z test
```

| MODE       | Result                       | httpx |
| ---------- | ---------------------------- | ----- |
| standalone | 113 passed, 0 failed         | PASS  |

## Diff scope

- `requirements/site-packages-base.txt` — +1 line.
- `doc/packages.md` — +1 row.
- `tests/func/test_117_httpx.py` — new file, 30 lines.

## Ramfs size increase

Measured on a clean tree (standalone mode). Baseline is
`feat/port-httpcore` (the stacked base, which already contains
`sniffio` + `anyio` + `h11` + `httpcore`). Cumulative delta from
`origin/main` reported separately.

|                                   | httpcore base  |  with `httpx`  | delta vs httpcore             |
| --------------------------------- | -------------: | -------------: | ----------------------------- |
| ramfs image (`nanvix_rootfs.img`) |   89,608,192 B |   90,124,288 B | **+516,096 B (+504.0 KiB)**   |
| stripped-sysroot content          |   59,736,408 B |   60,081,611 B | +345,203 B (+337.1 KiB)       |
| files in ramfs                    |          5,011 |          5,035 | +24                           |

Cumulative delta from `origin/main` through this PR (the full
closure landing). `origin/main` already contains the earlier
closure steps (`sniffio` + `anyio` + `h11`), so the cumulative
row here covers `httpcore` + `httpx`:

|                                   |  origin/main   | full closure  | cumulative delta              |
| --------------------------------- | -------------: | ------------: | ----------------------------- |
| ramfs image                       |   89,067,520 B |  90,124,288 B | **+1,056,768 B (+1.008 MiB)** |
| files in ramfs                    |          4,979 |         5,035 | +56                           |

New ramfs paths from this PR (httpx only): 24 entries under
`lib/python3.12/site-packages/httpx{,-0.28.1.dist-info}/`, including
the dormant `_async_client.pyc`, `_transports/asgi.pyc`, and
`_transports/wsgi.pyc` modules (present but unused; asgi/wsgi
adapters depend on async surfaces inert on Nanvix).

## Stacking

```
main
 └── #184 sniffio
      └── #185 anyio
           └── #187 h11
                └── #188 httpcore
                     └── this PR (httpx)   ← you are here
```

This is the top of the stack and closes the closure.

## Checklist

- [x] Diff scope matches the closure umbrella's step-4 plan
- [x] Smoke test follows the `test_NNN_<pkg>.py` convention
- [x] `httpx: PASS` verified locally on `standalone`
- [x] No `.nanvix/` / `patches/` / `Modules/Setup.local` edits
- [x] Ramfs size delta measured (see above)
- [x] `doc/packages.md` updated
- [x] Closure step 4 of 4 — `Closes #131`

