### PR TITLE
ci: bump workflows to v2.0.0 and zutils to v0.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       platforms: "[\"microvm\"]"
       process-modes: "[\"standalone\"]"
       memory-sizes: "[\"256mb\"]"
@@ -38,6 +38,7 @@ jobs:
       yaml-paths: ".github/workflows/ci.yml"
       release-notes-extra: |
         CPython 3.12.3 distribution for Nanvix with pure Python pip packages.
+      docker-image: "ghcr.io/nanvix/toolchain-python@sha256:2ef7213bfff85e927f18d8f0fc53063b9c6ffed236a6b30c92f6b4e148c2dec4" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -62,7 +63,7 @@ jobs:
       - name: Install nanvix-zutil
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          NANVIX_ZUTIL_VERSION: "v0.7.34"
+          NANVIX_ZUTIL_VERSION: "v0.8.1"
         shell: pwsh
         run: |
           $jq = '.assets[] | select(.name | endswith(".whl")) | .browser_download_url'
@@ -73,7 +74,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         shell: pwsh
-        run: nanvix-zutil setup
+        run: >-
+          nanvix-zutil setup --with-docker
+          ghcr.io/nanvix/toolchain-python@sha256:2ef7213bfff85e927f18d8f0fc53063b9c6ffed236a6b30c92f6b4e148c2dec4
 
       - name: Download Linux build artifact
         uses: actions/download-artifact@v5

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanvix-python"
 version = "3.12.3"
-nanvix-version = "0.12.538"
+nanvix-version = "0.12.547"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -407,7 +407,7 @@ class NanvixPythonBuild(ZScript):
         the directory is tarred into the container and extracted back.
         Falls back to skipping if Docker is not available.
         """
-        _DOCKER_IMAGE = "nanvix/toolchain:latest-minimal"
+        _DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-python:latest"
 
         if not docker_available():
             log.warning("Docker not available; skipping .pyc pre-compilation")

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.48"
+    "0.8.1"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.48"
+PINNED_VERSION="0.8.1"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
## Summary

Adapt caller workflow to breaking changes introduced by:
- `nanvix/workflows` v2.0.0 — `docker-image` is now a required input (no default).
- `nanvix/zutils` v0.8.0 — `setup --with-docker` requires an explicit image argument.

### Changes

- Bump `nanvix/workflows` from `v1.15.0` → `v2.0.0`
- Bump `zutil-version` from `v0.7.48` → `v0.8.1`
- Add required `docker-image` input (`ghcr.io/nanvix/toolchain-python` pinned by digest)
- Update `z.sh` and `z.ps1` pinned versions to `0.8.1`
- Bump `nanvix-version` to `0.12.547` in `nanvix.toml`
- Update dependency artifact pattern from `.tar.bz2` to `.tar.gz` (dependencies now ship as gzip)
- Monkey-patch `tarfile.open` for bz2-to-gz backward compatibility with zutil ≤0.8.1
- Update CPython asset download to use `.tar.gz`
- Update Docker image to `ghcr.io/nanvix/toolchain-python:latest` (published by nanvix/cpython)
- Release artifacts continue to ship as `.tar.bz2` (Linux) and `.zip` (Windows)

Reference: https://github.com/nanvix/sqlite/pull/190