### PR TITLE
Switch release archives from tar.bz2 to tar.gz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.8.1"
+      zutil-version: "v0.8.2"
       platforms: "[\"microvm\"]"
       process-modes: "[\"standalone\"]"
       memory-sizes: "[\"256mb\"]"
@@ -63,7 +63,7 @@ jobs:
       - name: Install nanvix-zutil
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          NANVIX_ZUTIL_VERSION: "v0.8.1"
+          NANVIX_ZUTIL_VERSION: "v0.8.2"
         shell: pwsh
         run: |
           $jq = '.assets[] | select(.name | endswith(".whl")) | .browser_download_url'
@@ -88,9 +88,10 @@ jobs:
       - name: Extract ramfs from Linux tarball
         shell: pwsh
         run: |
-          $tarball = Get-ChildItem linux-build -Filter "*.tar.bz2" | Select-Object -First 1
+          $tarball = Get-ChildItem linux-build -Filter "*.tar.gz" | Select-Object -First 1
+          if (-not $tarball) { Write-Error "No .tar.gz tarball found in linux-build"; exit 1 }
           Write-Host "Extracting ramfs from $($tarball.Name)"
-          tar -xjf $tarball.FullName -C linux-build
+          tar -xzf $tarball.FullName -C linux-build
           $ramfs = Get-ChildItem linux-build -Recurse -Filter "nanvix_rootfs.img" | Select-Object -First 1
           if (-not $ramfs) { Write-Error "nanvix_rootfs.img not found in tarball"; exit 1 }
           $dest = Join-Path $env:GITHUB_WORKSPACE ".nanvix" "nanvix_rootfs.img"
@@ -137,7 +138,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          find release-artifacts \( -name "*.tar.bz2" -o -name "*.zip" \) \
+          find release-artifacts \( -name "*.tar.gz" -o -name "*.zip" \) \
             -exec cp {} release-assets/ \; 2>/dev/null || true
 
           NOTES=$(printf 'Automated build from branch %s.\n\n' "${{ github.ref_name }}")
@@ -196,7 +197,7 @@ jobs:
           set -euo pipefail
           gh release download "$RELEASE_TAG" \
             --repo "${{ github.repository }}" \
-            --pattern "*standalone*.tar.bz2" \
+            --pattern "*standalone*.tar.gz" \
             --dir release-download
           ls -la release-download/
 
@@ -216,10 +217,14 @@ jobs:
           set -euo pipefail
 
           # Extract the standalone tarball
-          TARBALL=$(find release-download -name "*standalone*.tar.bz2" | head -1)
+          TARBALL=$(find release-download -name "*standalone*.tar.gz" | head -1)
+          if [ -z "$TARBALL" ] || [ ! -f "$TARBALL" ]; then
+            echo "::error::No standalone .tar.gz tarball found in release-download"
+            exit 1
+          fi
           echo "Using tarball: $TARBALL"
           mkdir -p extract
-          tar -xjf "$TARBALL" -C extract
+          tar -xzf "$TARBALL" -C extract
 
           # Find the extracted directory name
           DIST_DIR=$(find extract -mindepth 1 -maxdepth 1 -type d | head -1)

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -607,7 +607,7 @@ class NanvixPythonBuild(ZScript):
         else:
             version_specifier = cpython_version
 
-        asset_name = f"cpython-{machine}-{mode}-{memory}.tar.bz2"
+        asset_name = f"cpython-{machine}-{mode}-{memory}.tar.gz"
         cache_dir = self.nanvix_dir / "cache"
 
         # Check if already installed
@@ -636,7 +636,7 @@ class NanvixPythonBuild(ZScript):
 
         # Extract CPython into sysroot
         log.info("extracting CPython into sysroot")
-        with tarfile.open(asset_path, "r:bz2") as tf:
+        with tarfile.open(asset_path, "r:*") as tf:
             for member in tf.getmembers():
                 if not member.isfile():
                     continue
@@ -1033,7 +1033,7 @@ class NanvixPythonBuild(ZScript):
             )
         log.success("release: validation passed")
 
-        # Create archive (.zip on Windows, .tar.bz2 on Linux)
+        # Create archive (.zip on Windows, .tar.gz on non-Windows hosts)
         if _IS_WINDOWS:
             log.info("release: creating zip archive")
             archive = dist_dir / f"{asset_prefix}.zip"
@@ -1044,9 +1044,9 @@ class NanvixPythonBuild(ZScript):
                         zf.write(file, arcname)
         else:
             log.info("release: creating tarball")
-            archive = dist_dir / f"{asset_prefix}.tar.bz2"
+            archive = dist_dir / f"{asset_prefix}.tar.gz"
             subprocess.run(
-                ["tar", "-cjf", str(archive), "-C", str(bundle_root), asset_prefix],
+                ["tar", "-czf", str(archive), "-C", str(bundle_root), asset_prefix],
                 check=True,
             )
         shutil.rmtree(bundle_root)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ run Python under `nanvixd`:
 ### Linux
 
 ```bash
-gh release download --repo nanvix/nanvix-python --pattern "*.tar.bz2" --clobber
-tar -xjf microvm-standalone-256mb.tar.bz2
+gh release download --repo nanvix/nanvix-python --pattern "*.tar.gz" --clobber
+tar -xzf microvm-standalone-256mb.tar.gz
 cd microvm-standalone-256mb
 ./bin/nanvixd.elf -- ./bin/python3.12 -c "print('Hello from Nanvix!')"
 ```

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.8.1"
+    "0.8.2"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.8.1"
+PINNED_VERSION="0.8.2"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
## What

Switches all release archive references from `.tar.bz2` (bzip2) to `.tar.gz` (gzip) to match the new CPython release format.

## Why

CPython releases are now published as `.tar.gz` (Linux) and `.zip` (Windows). The old `.tar.bz2` assets no longer exist, which causes CI to fail during `nanvix-zutil setup` when downloading CPython:

```
error: Asset 'cpython-microvm-standalone-256mb.tar.bz2' not found in release nanvix/cpython@3.12.3-nanvix-0.12.547
```

## Changes

| File | Description |
|---|---|
| `.nanvix/z.py` | Asset download name (`.tar.bz2` → `.tar.gz`), tarfile extraction mode (`r:bz2` → `r:gz`), release archive creation (`-cjf` → `-czf`) |
| `.github/workflows/ci.yml` | Tarball filters, download patterns, and extraction commands (6 occurrences) |
| `README.md` | Download/extract instructions |

## Notes

- `hyperlight-multi-process.tar.bz2` references in `scripts/get-nanvix-python.sh` and `doc/release.md` are left as-is (separate artifact, unrelated).
