### PR TITLE
[ci] E: Update nanvix workflow refs to v2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
       zutil-version: "v0.8.2"
       platforms: "[\"microvm\"]"


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.0.1`](https://github.com/nanvix/workflows/releases/tag/v2.0.1).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.