### PR TITLE
fix: adapt to Nanvix v0.14.3 breaking changes (initrd-based standalone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
     with:
-      zutil-version: "v0.8.5"
+      zutil-version: "v0.9.2"
       platforms: "[\"microvm\"]"
       process-modes: "[\"standalone\"]"
       memory-sizes: "[\"256mb\"]"
+      skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: false
       python-paths: ".nanvix/z.py tests/smoke_test_l2.py"
@@ -64,7 +65,7 @@ jobs:
       - name: Install nanvix-zutil
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          NANVIX_ZUTIL_VERSION: "v0.8.2"
+          NANVIX_ZUTIL_VERSION: "v0.9.2"
         shell: pwsh
         run: |
           $jq = '.assets[] | select(.name | endswith(".whl")) | .browser_download_url'

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ release-assets/
 dist/
 elf-binaries/
 
+# Temporary binary copy used by make_initrd (standalone mode)
+python3.12
+
 logs/

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanvix-python"
 version = "3.12.3"
-nanvix-version = "0.13.17"
+nanvix-version = "0.14.7"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -35,7 +35,6 @@ from nanvix_zutil import (
     ZScript,
     log,
 )
-from nanvix_zutil.docker import docker_available
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
     EXIT_MISSING_DEP,
@@ -99,6 +98,19 @@ class NanvixPythonBuild(ZScript):
                 return name
         return None
 
+    def _ensure_python_in_repo_root(self, sysroot: Path) -> None:
+        """Copy python3.12 to repo_root for make_initrd if not already present."""
+        repo_python = self.repo_root / "python3.12"
+        if repo_python.exists():
+            return
+        python_bin = sysroot / "bin" / "python3.12"
+        shutil.copy2(python_bin, repo_python)
+
+    def _cleanup_python_in_repo_root(self) -> None:
+        """Remove the python3.12 copy from repo_root."""
+        repo_python = self.repo_root / "python3.12"
+        repo_python.unlink(missing_ok=True)
+
     def _nanvix_run(
         self,
         sysroot: Path,
@@ -112,6 +124,10 @@ class NanvixPythonBuild(ZScript):
         Uses nanvixd.exe on Windows and nanvixd.elf on Linux/macOS.
         Captures output to *log_file*.  Does NOT raise on non-zero exit
         (the caller inspects the log for PASS/FAIL).
+
+        In standalone mode, bundles python3.12 with system daemons into
+        an initrd via make_initrd; a ramfs provides the filesystem
+        (stdlib, site-packages, test scripts).
         """
         if timeout is None:
             timeout = int(os.environ.get("TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT)))
@@ -127,6 +143,13 @@ class NanvixPythonBuild(ZScript):
                     code=EXIT_MISSING_DEP,
                     hint="Run `./z build` first.",
                 )
+            # Bundle python3.12 + system daemons into an initrd.
+            self._ensure_python_in_repo_root(sysroot)
+            initrd = self.make_initrd(
+                "python3.12",
+                app_args=["-B", f"/sysroot/{script_path}"],
+                app_env=["PYTHONHOME=/sysroot", "PYTHONDONTWRITEBYTECODE=1"],
+            )
             cmd = [
                 nanvixd,
                 "-bin-dir",
@@ -134,9 +157,23 @@ class NanvixPythonBuild(ZScript):
                 "-ramfs",
                 str(self._ramfs_img),
                 "--",
-                f"./bin/python3.12",
-                f"-B /sysroot/{script_path};PYTHONHOME=/sysroot PYTHONDONTWRITEBYTECODE=1",
+                str(initrd),
             ]
+            with log_file.open("w") as fh:
+                try:
+                    subprocess.run(
+                        cmd,
+                        cwd=sysroot,
+                        stdin=subprocess.DEVNULL,
+                        stdout=fh,
+                        stderr=fh,
+                        timeout=timeout,
+                    )
+                except subprocess.TimeoutExpired:
+                    fh.write(f"\nTIMEOUT after {timeout}s\n")
+                finally:
+                    if initrd.exists():
+                        initrd.unlink()
         else:
             cmd = [
                 nanvixd,
@@ -144,19 +181,18 @@ class NanvixPythonBuild(ZScript):
                 f"./bin/python3.12",
                 f"./{script_path}",
             ]
-
-        with log_file.open("w") as fh:
-            try:
-                subprocess.run(
-                    cmd,
-                    cwd=sysroot,
-                    stdin=subprocess.DEVNULL,
-                    stdout=fh,
-                    stderr=fh,
-                    timeout=timeout,
-                )
-            except subprocess.TimeoutExpired:
-                fh.write(f"\nTIMEOUT after {timeout}s\n")
+            with log_file.open("w") as fh:
+                try:
+                    subprocess.run(
+                        cmd,
+                        cwd=sysroot,
+                        stdin=subprocess.DEVNULL,
+                        stdout=fh,
+                        stderr=fh,
+                        timeout=timeout,
+                    )
+                except subprocess.TimeoutExpired:
+                    fh.write(f"\nTIMEOUT after {timeout}s\n")
 
     # -- Standalone / ramfs helpers ----------------------------------------
 
@@ -419,7 +455,7 @@ class NanvixPythonBuild(ZScript):
         """
         _DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-python:latest"
 
-        if not docker_available():
+        if shutil.which("docker") is None:
             log.warning("Docker not available; skipping .pyc pre-compilation")
             return
 
@@ -778,6 +814,7 @@ class NanvixPythonBuild(ZScript):
                 self._run_functional_tests(sysroot, exclude_tests)
         finally:
             self._cleanup_ramfs()
+            self._cleanup_python_in_repo_root()
 
     def _run_smoke_test(self, sysroot: Path) -> None:
         """Run the layer-2 smoke test."""
@@ -1103,6 +1140,8 @@ class NanvixPythonBuild(ZScript):
         nanvixd_bin = str(nanvixd.resolve())
         timeout = int(os.environ.get("TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT)))
 
+        initrd: Path | None = None
+
         if deployment == "standalone":
             self._ensure_ramfs(sysroot)
             if not self._ramfs_img or not self._ramfs_img.is_file():
@@ -1111,6 +1150,13 @@ class NanvixPythonBuild(ZScript):
                     code=EXIT_MISSING_DEP,
                     hint="Run `./z build` first.",
                 )
+            # Bundle python3.12 + system daemons into an initrd.
+            self._ensure_python_in_repo_root(sysroot)
+            initrd = self.make_initrd(
+                "python3.12",
+                app_args=["-c", 'print("hello")'],
+                app_env=["PYTHONHOME=/sysroot", "PYTHONDONTWRITEBYTECODE=1"],
+            )
             cmd = [
                 nanvixd_bin,
                 "-bin-dir",
@@ -1118,8 +1164,7 @@ class NanvixPythonBuild(ZScript):
                 "-ramfs",
                 str(self._ramfs_img),
                 "--",
-                "./bin/python3.12",
-                '-c print("hello");PYTHONHOME=/sysroot PYTHONDONTWRITEBYTECODE=1',
+                str(initrd),
             ]
         else:
             cmd = [
@@ -1146,6 +1191,9 @@ class NanvixPythonBuild(ZScript):
                 )
             except subprocess.TimeoutExpired:
                 fh.write(f"\nTIMEOUT after {timeout}s\n")
+            finally:
+                if initrd is not None and initrd.exists():
+                    initrd.unlink()
         elapsed = time.perf_counter() - start
 
         output = log_file.read_text(errors="replace") if log_file.is_file() else ""
@@ -1153,6 +1201,7 @@ class NanvixPythonBuild(ZScript):
 
         if deployment == "standalone":
             self._cleanup_ramfs()
+            self._cleanup_python_in_repo_root()
 
         if "hello" not in output:
             print(output)
@@ -1179,6 +1228,9 @@ class NanvixPythonBuild(ZScript):
         ramfs_img.unlink(missing_ok=True)
         ramfs_sentinel = self.nanvix_dir / ".ramfs-built"
         ramfs_sentinel.unlink(missing_ok=True)
+
+        # Clean python3.12 copy used by make_initrd
+        self._cleanup_python_in_repo_root()
 
         log.success("clean complete")
 

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.8.5"
+    "0.9.2"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -42,9 +42,10 @@ catch {
 }
 
 function Bootstrap {
+    param([string]$Reason = "not found")
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil not found -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
 
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
 
@@ -115,6 +116,11 @@ else {
     $bin = "nanvix-zutil"
     if ($zutilGlobalVersion -ne "nanvix-zutil ${zutilVersion}") {
         Write-Warning "nanvix-zutil global install does not match expected version. Expected ${zutilVersion}, found ${zutilGlobalVersion}."
+        Bootstrap "version mismatch"
+        if (-not (Test-Path $venvZutil)) {
+            throw "Bootstrap completed but $venvZutil not found."
+        }
+        $bin = $venvZutil
     }
 }
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.8.5"
+PINNED_VERSION="0.9.2"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -31,7 +31,8 @@ ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    echo "nanvix-zutil not found -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+    local reason="${1:-not found}"
+    echo "nanvix-zutil ${reason} -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 
     if ! command -v python3 &>/dev/null; then
         echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
@@ -69,6 +70,8 @@ else
     BIN="nanvix-zutil"
     if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
         echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+        bootstrap "version mismatch"
+        BIN="$VENV_BIN"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Adapts nanvix-python to the Nanvix v0.14.3 breaking change: standalone binaries must now be bundled into a multi-binary initrd (with system daemons) via `make_initrd`, rather than being passed directly after `--` to `nanvixd`.

## Changes

### `.nanvix/z.py`
- Add `_ensure_python_in_repo_root(sysroot)` helper — copies `python3.12` to repo root (required by `make_initrd` path resolution)
- Add `_cleanup_python_in_repo_root()` helper for cleanup
- Refactor `_nanvix_run()` standalone branch: create initrd per test invocation, pass initrd path after `--`
- Refactor `benchmark()` standalone branch: same initrd pattern
- Update `test()` and `clean()` with proper cleanup calls
- **Non-standalone paths remain unchanged**

### `.nanvix/nanvix.toml`
- Bump `nanvix-version` to `0.14.3`

### `z.sh` / `z.ps1`
- Pin `nanvix-zutil` to `v0.9.0`

### `.github/workflows/ci.yml`
- Update nanvix-zutil version reference

## Notes

- The ramfs image is **still created** for input/output files and the Python stdlib/site-packages
- **No test programs are disabled** by this change; existing standalone exclusions (plotly, setuptools, wheel) remain as they are stripped from the ramfs for size reasons
- Follows the same pattern established in nanvix-zlib, nanvix-bzip2, nanvix-xz, and nanvix-quickjs