### PR TITLE
Pass org-level DISPATCH_TOKEN to reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       docker-image: "ghcr.io/nanvix/toolchain-python@sha256:2ef7213bfff85e927f18d8f0fc53063b9c6ffed236a6b30c92f6b4e148c2dec4" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-      DISPATCH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
   # Custom Windows test that reuses the ramfs image from the Linux build
   # instead of rebuilding it (Docker can't run the Linux toolchain image


### PR DESCRIPTION
The `DISPATCH_TOKEN` secret passed to the reusable workflow was mapped to `secrets.GH_TOKEN` (repo-level, `public_repo` scope only) instead of `secrets.DISPATCH_TOKEN` (org-level, with `read:org` + admin access).

This caused the **Update Nanvix Version** job to fail with a GraphQL scope error when creating PRs:

```
GraphQL: Your token has not been granted the required scopes to execute this query.
The 'login' field requires one of the following scopes: ['read:org'],
but your token has only been granted the: ['public_repo'] scopes.
```

**Fix:** Reference `secrets.DISPATCH_TOKEN` first in the fallback chain:
```yaml
DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
```

Fixes job [76586917735](https://github.com/nanvix/nanvix-python/actions/runs/26047277704/job/76586917735).