### PR TITLE
[ci] E: Update nanvix workflow refs to v2.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
     with:
       zutil-version: "v0.8.5"
       platforms: "[\"microvm\"]"


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.0.2`](https://github.com/nanvix/workflows/releases/tag/v2.0.2).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.