### PR TITLE
Dont ship pre-built snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,6 @@ jobs:
         shell: pwsh
         run: nanvix-zutil test
 
-      - name: Upload VM snapshots
-        uses: actions/upload-artifact@v5
-        with:
-          name: nanvix-python-snapshots
-          path: .nanvix/sysroot/snapshots/
-          if-no-files-found: error
-
   release:
     needs: ci
     if: github.event_name != 'pull_request'
@@ -199,6 +192,8 @@ jobs:
       RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
       NANVIX_TAG: ${{ needs.ci.outputs.nanvix_tag }}
     steps:
+      - uses: actions/checkout@v5
+
       - name: Download standalone tarball from release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -220,12 +215,6 @@ jobs:
             --pattern "nanvix-windows-x86-microvm-standalone*256mb*.zip" \
             --dir nanvix-windows
           ls -la nanvix-windows/
-
-      - name: Download VM snapshots
-        uses: actions/download-artifact@v5
-        with:
-          name: nanvix-python-snapshots
-          path: snapshots
 
       - name: Create Windows zip
         run: |
@@ -257,10 +246,10 @@ jobs:
           cp nanvix-win-extract/nanvixd.exe "$DIST_DIR/bin/nanvixd.exe"
           cp nanvix-win-extract/kernel.elf "$DIST_DIR/bin/kernel.elf"
 
-          # Include VM snapshots for warm-start restore
-          mkdir -p "$DIST_DIR/snapshots"
-          cp snapshots/* "$DIST_DIR/snapshots/"
-          echo "Included snapshots: $(ls "$DIST_DIR/snapshots/")"
+          # Replace the Linux-built README with the top-level
+          # README.md (which documents the Windows workflow,
+          # including snapshot generation and warm restore).
+          cp README.md "$DIST_DIR/README.md"
 
           # Create the Windows zip
           ZIP_NAME="${DIR_NAME}.zip"

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -127,8 +127,7 @@ class NanvixPythonBuild(ZScript):
 
         In standalone mode, uses the cached initrd (with _boot.py entry
         point) and communicates the script to run via a mounted directory
-        containing an argv.txt file.  If a snapshot exists, restores from
-        it for faster startup.
+        containing an argv.txt file.
         """
         if timeout is None:
             timeout = int(os.environ.get("TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT)))
@@ -160,16 +159,9 @@ class NanvixPythonBuild(ZScript):
                 str(self._ramfs_img),
                 "-mount",
                 str(mount_dir),
+                "--",
+                str(initrd),
             ]
-
-            # Snapshot support is Windows-only (WHP).
-            snapshot_cbor = sysroot / "snapshots" / "kernel.whp.cbor"
-            if _IS_WINDOWS:
-                cmd.extend(["-kernel-args", "snapshot"])
-                if snapshot_cbor.is_file():
-                    cmd.extend(["-snapshot", str(snapshot_cbor)])
-
-            cmd.extend(["--", str(initrd)])
 
             with log_file.open("w") as fh:
                 try:
@@ -210,7 +202,6 @@ class NanvixPythonBuild(ZScript):
     _ramfs_img: Path | None = None
     _stripped_sysroot: Path | None = None
     _initrd: Path | None = None
-    _snapshot_dir: Path | None = None
 
     def _ramfs_input_hash(self, sysroot: Path) -> str:
         """Compute a hash representing the current ramfs inputs."""
@@ -593,104 +584,32 @@ class NanvixPythonBuild(ZScript):
         """Build or reuse the multi-binary initrd with _boot.py as entry point.
 
         The initrd bundles python3.12 + system daemons and uses the
-        nanvix._boot warm-start protocol as entry point.  The caller
-        must pass ``-kernel-args snapshot`` to nanvixd to enable
-        snapshot support in the kernel.
+        nanvix._boot warm-start protocol as entry point.
         """
         if self._initrd and self._initrd.is_file():
             return self._initrd
 
         self._ensure_python_in_repo_root(sysroot)
-        initrd = self.make_initrd(
-            "python3.12",
-            app_args=[
-                "-S",
-                "-O",
-                "-B",
-                "-X",
-                "frozen_modules=on",
-                "/sysroot/_boot.pyc",
-            ],
-            app_env=[
-                "PYTHONHOME=/sysroot",
-                "PYTHONPATH=/sysroot/lib/python3.12/site-packages",
-                "PYTHONDONTWRITEBYTECODE=1",
-            ],
+        initrd: Path = (
+            self.make_initrd(  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                "python3.12",
+                app_args=[
+                    "-S",
+                    "-O",
+                    "-B",
+                    "-X",
+                    "frozen_modules=on",
+                    "/sysroot/_boot.pyc",
+                ],
+                app_env=[
+                    "PYTHONHOME=/sysroot",
+                    "PYTHONPATH=/sysroot/lib/python3.12/site-packages",
+                    "PYTHONDONTWRITEBYTECODE=1",
+                ],
+            )
         )
         self._initrd = initrd
         return initrd
-
-    def _generate_snapshot(self, sysroot: Path) -> Path:
-        """Generate VM snapshot via cold boot (no -mount).
-
-        Boots nanvixd with the initrd and ramfs. The _boot.py entry
-        point calls nanvix.snapshot() then tries nanvix.mount() which
-        fails (no -mount flag), causing a clean exit. Snapshot files
-        are written to sysroot/snapshots/.
-
-        Returns the path to the snapshots directory.
-        """
-        if not self._ramfs_img or not self._ramfs_img.is_file():
-            log.fatal(
-                "ramfs image not found (required for snapshot generation).",
-                code=EXIT_MISSING_DEP,
-                hint="Run `./z build` first.",
-            )
-
-        initrd = self._ensure_initrd(sysroot)
-        nanvixd = str((sysroot / "bin" / _nanvixd_binary()).resolve())
-        timeout = int(os.environ.get("TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT)))
-
-        snapshots_dir = sysroot / "snapshots"
-        snapshots_dir.mkdir(exist_ok=True)
-
-        log.info("generating VM snapshot (cold boot)")
-        tmp = Path(tempfile.gettempdir())
-        log_file = tmp / "snapshot-gen.log"
-
-        cmd = [
-            nanvixd,
-            "-bin-dir",
-            str((sysroot / "bin").resolve()),
-            "-ramfs",
-            str(self._ramfs_img),
-            "-kernel-args",
-            "snapshot",
-            "--",
-            str(initrd),
-        ]
-        with log_file.open("w") as fh:
-            try:
-                subprocess.run(
-                    cmd,
-                    cwd=sysroot,
-                    stdin=subprocess.DEVNULL,
-                    stdout=fh,
-                    stderr=fh,
-                    timeout=timeout,
-                )
-            except subprocess.TimeoutExpired:
-                fh.write(f"\nTIMEOUT after {timeout}s\n")
-                log.fatal(
-                    "snapshot generation timed out",
-                    code=EXIT_BUILD_FAILURE,
-                )
-
-        # Verify snapshot files were created
-        vmem = snapshots_dir / "kernel.vmem"
-        cbor = snapshots_dir / "kernel.whp.cbor"
-        if not vmem.is_file() or not cbor.is_file():
-            output = log_file.read_text(errors="replace") if log_file.is_file() else ""
-            print(output)
-            log.fatal(
-                "snapshot generation failed — snapshot files not found",
-                code=EXIT_BUILD_FAILURE,
-            )
-        log_file.unlink(missing_ok=True)
-
-        self._snapshot_dir = snapshots_dir
-        log.success("VM snapshot generated")
-        return snapshots_dir
 
     def _cleanup_initrd(self) -> None:
         """Remove the cached initrd file."""
@@ -988,14 +907,6 @@ class NanvixPythonBuild(ZScript):
             else:
                 self._ensure_ramfs(sysroot)
 
-            # Generate snapshot for warm-start test execution.
-            # This cold-boots once; all subsequent test runs restore
-            # from the snapshot, skipping kernel/daemon/CPython init.
-            # Snapshots are only supported on Windows (WHP); Linux/KVM
-            # CI runs use cold boot for each test.
-            if _IS_WINDOWS:
-                self._generate_snapshot(sysroot)
-
         # Standalone exclusions
         exclude_tests = os.environ.get("EXCLUDE_TESTS", "")
         if deployment == "standalone" and not exclude_tests:
@@ -1003,13 +914,16 @@ class NanvixPythonBuild(ZScript):
             exclude_tests = "83 89 90"
 
         # Determine which tests to run
-        targets = (
-            set(self.targets) if self.targets else {"test-smoke", "test-integration"}
-        )
+        default_targets = {"test-smoke", "test-integration"}
+        if deployment == "standalone" and _IS_WINDOWS:
+            default_targets.add("test-snapshot")
+        targets = set(self.targets) if self.targets else default_targets
 
         try:
             if "test-smoke" in targets:
                 self._run_smoke_test(sysroot)
+            if "test-snapshot" in targets:
+                self._run_snapshot_smoke_test(sysroot)
             if "test-integration" in targets:
                 self._run_functional_tests(sysroot, exclude_tests)
         finally:
@@ -1042,6 +956,134 @@ class NanvixPythonBuild(ZScript):
             print(output)
         else:
             log.fatal("smoke test produced no output", code=EXIT_TEST_FAILURE)
+
+    def _run_snapshot_smoke_test(self, sysroot: Path) -> None:
+        """Smoke test: generate a VM snapshot then warm-restore hello-world.
+
+        Snapshots are only supported on Windows (WHP) and are not
+        portable across machines, so this test is host-local.  It:
+
+          1. Cold-boots nanvixd with ``-kernel-args snapshot`` (no
+             ``-mount``).  The _boot.py entry point calls
+             ``nanvix.snapshot()`` then ``nanvix.mount()`` which fails
+             (no mount provided), causing a clean exit.  The snapshot
+             files are written to ``sysroot/snapshots/``.
+          2. Warm-restores from the snapshot with a ``-mount`` directory
+             whose ``bootstrap.py`` prints ``hello`` and checks for that
+             output.
+        """
+        if not _IS_WINDOWS:
+            log.info("snapshot smoke test: skipped (Windows-only / WHP)")
+            return
+        if self.config.deployment_mode != "standalone":
+            log.info("snapshot smoke test: skipped (standalone-only)")
+            return
+        if not self._ramfs_img or not self._ramfs_img.is_file():
+            log.fatal(
+                "ramfs image not found (required for snapshot smoke test).",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z build` first.",
+            )
+
+        log.info("=== snapshot smoke test ===")
+        initrd = self._ensure_initrd(sysroot)
+        nanvixd = str((sysroot / "bin" / _nanvixd_binary()).resolve())
+        timeout = int(os.environ.get("TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT)))
+
+        snapshots_dir = sysroot / "snapshots"
+        snapshots_dir.mkdir(exist_ok=True)
+        vmem = snapshots_dir / "kernel.vmem"
+        cbor = snapshots_dir / "kernel.whp.cbor"
+        vmem.unlink(missing_ok=True)
+        cbor.unlink(missing_ok=True)
+
+        tmp = Path(tempfile.gettempdir())
+
+        # --- Phase 1: cold boot to generate snapshot ---------------------
+        log.info("snapshot smoke test: generating snapshot (cold boot)")
+        gen_log = tmp / "snapshot-gen.log"
+        gen_cmd = [
+            nanvixd,
+            "-bin-dir",
+            str((sysroot / "bin").resolve()),
+            "-ramfs",
+            str(self._ramfs_img),
+            "-kernel-args",
+            "snapshot",
+            "--",
+            str(initrd),
+        ]
+        with gen_log.open("w") as fh:
+            try:
+                subprocess.run(
+                    gen_cmd,
+                    cwd=sysroot,
+                    stdin=subprocess.DEVNULL,
+                    stdout=fh,
+                    stderr=fh,
+                    timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                fh.write(f"\nTIMEOUT after {timeout}s\n")
+                log.fatal(
+                    "snapshot smoke test: generation timed out",
+                    code=EXIT_TEST_FAILURE,
+                )
+
+        if not vmem.is_file() or not cbor.is_file():
+            print(gen_log.read_text(errors="replace") if gen_log.is_file() else "")
+            log.fatal(
+                "snapshot smoke test: snapshot files not produced",
+                code=EXIT_TEST_FAILURE,
+            )
+        gen_log.unlink(missing_ok=True)
+
+        # --- Phase 2: warm restore to run hello-world --------------------
+        log.info("snapshot smoke test: warm-restoring to run hello-world")
+        mount_dir = Path(tempfile.mkdtemp(prefix="nanvix-snap-smoke-"))
+        (mount_dir / "bootstrap.py").write_text('print("hello")\n')
+        run_log = tmp / "snapshot-run.log"
+        run_cmd = [
+            nanvixd,
+            "-bin-dir",
+            str((sysroot / "bin").resolve()),
+            "-snapshot",
+            str(cbor),
+            "-ramfs",
+            str(self._ramfs_img),
+            "-mount",
+            str(mount_dir),
+            "-kernel-args",
+            "snapshot",
+            "--",
+            str(initrd),
+        ]
+        try:
+            with run_log.open("w") as fh:
+                try:
+                    subprocess.run(
+                        run_cmd,
+                        cwd=sysroot,
+                        stdin=subprocess.DEVNULL,
+                        stdout=fh,
+                        stderr=fh,
+                        timeout=timeout,
+                    )
+                except subprocess.TimeoutExpired:
+                    fh.write(f"\nTIMEOUT after {timeout}s\n")
+        finally:
+            shutil.rmtree(mount_dir, ignore_errors=True)
+
+        output = run_log.read_text(errors="replace") if run_log.is_file() else ""
+        run_log.unlink(missing_ok=True)
+
+        if "hello" not in output:
+            print(output)
+            log.fatal(
+                "snapshot smoke test: expected 'hello' not found in output",
+                code=EXIT_TEST_FAILURE,
+            )
+        log.success("snapshot smoke test: PASS")
 
     def _run_functional_tests(self, sysroot: Path, exclude_tests: str) -> None:
         """Run the numbered functional tests."""
@@ -1243,17 +1285,6 @@ class NanvixPythonBuild(ZScript):
                 initrd = self._ensure_initrd(sysroot)
                 shutil.copy2(initrd, bundle_dir / "python3.initrd")
 
-                # Generate VM snapshot for warm-start restore
-                # Snapshots are only supported on Windows (WHP).
-                if _IS_WINDOWS:
-                    log.info("release: generating VM snapshot")
-                    snapshots_dir = self._generate_snapshot(sysroot)
-                    bundle_snapshots = bundle_dir / "snapshots"
-                    bundle_snapshots.mkdir(exist_ok=True)
-                    for snap_file in snapshots_dir.iterdir():
-                        if snap_file.is_file():
-                            shutil.copy2(snap_file, bundle_snapshots)
-
                 # Create mnt/ directory for user workloads
                 (bundle_dir / "mnt").mkdir(exist_ok=True)
 
@@ -1267,13 +1298,6 @@ class NanvixPythonBuild(ZScript):
                 f"./bin/{nanvixd_name} -ramfs nanvix_rootfs.img"
                 f" -mount ./mnt -- python3.initrd"
             )
-            warm_cmd = (
-                f"./bin/{nanvixd_name} -snapshot snapshots/kernel.whp.cbor"
-                f" -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd"
-            )
-            snap_cmd = (
-                f"./bin/{nanvixd_name} -ramfs nanvix_rootfs.img" f" -- python3.initrd"
-            )
             readme_text = (
                 f"# Nanvix Python Runtime\n\n"
                 f"Platform: {platform_name}\n"
@@ -1286,16 +1310,6 @@ class NanvixPythonBuild(ZScript):
                 f"```\n\n"
                 f"On startup CPython executes `/mnt/bootstrap.py` if present,\n"
                 f"otherwise it drops into an interactive REPL.\n\n"
-                f"## Fast Start (warm restore via snapshot)\n\n"
-                f"A pre-built snapshot is included in `snapshots/`. "
-                f"Restore from it to skip cold boot + Python initialization:\n\n"
-                f"```sh\n"
-                f"{warm_cmd}\n"
-                f"```\n\n"
-                f"To recreate the snapshot (e.g. after updating the ramfs):\n\n"
-                f"```sh\n"
-                f"{snap_cmd}\n"
-                f"```\n\n"
                 f"## Running Your Own Script\n\n"
                 f"Place a `bootstrap.py` in a directory and mount it:\n\n"
                 f"```sh\n"
@@ -1332,13 +1346,6 @@ class NanvixPythonBuild(ZScript):
                     "python3.initrd",
                 ]
             )
-            if _IS_WINDOWS:
-                required.extend(
-                    [
-                        "snapshots/kernel.vmem",
-                        "snapshots/kernel.whp.cbor",
-                    ]
-                )
         else:
             required.extend(
                 [
@@ -1436,16 +1443,9 @@ class NanvixPythonBuild(ZScript):
                 str(self._ramfs_img),
                 "-mount",
                 str(mount_dir),
+                "--",
+                str(initrd),
             ]
-
-            # Snapshot support is Windows-only (WHP).
-            snapshot_cbor = sysroot / "snapshots" / "kernel.whp.cbor"
-            if _IS_WINDOWS:
-                cmd.extend(["-kernel-args", "snapshot"])
-                if snapshot_cbor.is_file():
-                    cmd.extend(["-snapshot", str(snapshot_cbor)])
-
-            cmd.extend(["--", str(initrd)])
         else:
             cmd = [
                 nanvixd_bin,
@@ -1514,7 +1514,7 @@ class NanvixPythonBuild(ZScript):
         # Clean initrd
         self._cleanup_initrd()
 
-        # Clean snapshot artifacts
+        # Clean snapshot artifacts produced by the snapshot smoke test
         sysroot_str = self.config.get(CFG_SYSROOT, "")
         if sysroot_str:
             snapshots_dir = Path(sysroot_str) / "snapshots"

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ run Python under `nanvixd`:
 gh release download --repo nanvix/nanvix-python --pattern "*.tar.gz" --clobber
 tar -xzf microvm-standalone-256mb.tar.gz
 cd microvm-standalone-256mb
-./bin/nanvixd.elf -snapshot snapshots/kernel.whp.cbor -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd
+./bin/nanvixd.elf -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd
 ```
+
+On startup `nanvixd` mounts the host `mnt/` directory at `/mnt`
+inside the guest, then CPython executes `/mnt/bootstrap.py` if
+present. Otherwise it drops into an interactive REPL.
 
 ### Windows
 
@@ -27,30 +31,74 @@ cd microvm-standalone-256mb
 gh release download --repo nanvix/nanvix-python --pattern "*.zip" --clobber
 Expand-Archive microvm-standalone-256mb.zip -DestinationPath .
 cd microvm-standalone-256mb
-.\bin\nanvixd.exe -snapshot snapshots\kernel.whp.cbor -ramfs nanvix_rootfs.img -mount .\mnt -- python3.initrd
+.\bin\nanvixd.exe -ramfs nanvix_rootfs.img -mount .\mnt -- python3.initrd
 ```
 
-The release ships with a **pre-built snapshot** so there is no cold
-boot overhead on first run. On restore, `nanvixd` mounts the host
-`mnt/` directory at `/mnt` inside the guest, then CPython executes
-`/mnt/bootstrap.py` if present. Otherwise it drops into an interactive
-REPL.
+#### Fast Start (warm restore via snapshot)
+
+Snapshots let you skip the cold boot + Python initialization on
+every run. They are only supported on Windows (via the Windows
+Hypervisor Platform — WHP) and are **hardware-specific**, so they
+cannot be shipped pre-built: each user must generate one locally
+on the host that will restore from it. Cold boot takes ~2 s, so
+generation is a one-time cost.
+
+##### Generating a snapshot
+
+From the bundle directory, cold-boot once with `-kernel-args
+snapshot` and no `-mount`:
+
+```powershell
+mkdir snapshots -ErrorAction SilentlyContinue
+.\bin\nanvixd.exe -bin-dir .\bin -ramfs nanvix_rootfs.img `
+    -kernel-args snapshot -- python3.initrd
+```
+
+The VM exits cleanly after the kernel writes the snapshot. Confirm
+success with:
+
+```powershell
+Get-ChildItem snapshots\kernel.vmem, snapshots\kernel.whp.cbor
+```
+
+##### Restoring from a snapshot
+
+Once a snapshot exists, every subsequent run can warm-restore from
+it:
+
+```powershell
+.\bin\nanvixd.exe -snapshot snapshots\kernel.whp.cbor `
+    -ramfs nanvix_rootfs.img -mount .\mnt `
+    -kernel-args snapshot -- python3.initrd
+```
+
+##### Regenerating a snapshot
+
+A snapshot is tied to both the host hardware and the contents of
+the ramfs image. Regenerate it whenever you:
+
+- move the bundle to a different machine (or change CPU features);
+- replace `nanvix_rootfs.img` or `python3.initrd`;
+- upgrade to a new release.
+
+Delete `snapshots\` and repeat the generation step above.
 
 ### Release Bundle Layout
 
 ```
 microvm-standalone-256mb/
 ├── bin/
-│   ├── kernel.elf          # Nanvix microkernel
-│   └── nanvixd.exe (.elf)  # Host-side hypervisor
-├── mnt/                    # Place your workload here
-├── snapshots/
-│   ├── kernel.vmem         # Pre-built memory snapshot (256 MB)
-│   └── kernel.whp.cbor    # Pre-built VM state
-├── nanvix_rootfs.img       # RAMFS with CPython stdlib + packages
-├── python3.initrd          # Multi-binary initrd (daemons + CPython)
+│   ├── kernel.elf            # Nanvix microkernel
+│   └── nanvixd.exe (.elf)    # Host-side hypervisor
+├── mnt/                      # Place your workload here
+├── nanvix_rootfs.img         # RAMFS with CPython stdlib + packages
+├── python3.initrd            # Multi-binary initrd (daemons + CPython)
 └── README.md
 ```
+
+On Windows, generating a snapshot (see *Fast Start* above) creates
+a `snapshots/` directory in the bundle containing `kernel.vmem`
+and `kernel.whp.cbor`.
 
 ### Workload Dispatch
 
@@ -69,34 +117,6 @@ import json
 print(json.dumps({"hello": "nanvix"}))
 ```
 
-### Cold Boot (Without Snapshot)
-
-To run without the pre-built snapshot (full cold boot):
-
-```bash
-# Linux
-./bin/nanvixd.elf -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd
-
-# Windows
-.\bin\nanvixd.exe -ramfs nanvix_rootfs.img -mount .\mnt -- python3.initrd
-```
-
-### Recreating the Snapshot
-
-If you need to regenerate the snapshot (e.g., after modifying the
-ramfs), run without `-mount` and without `-snapshot`:
-
-```bash
-# Linux
-./bin/nanvixd.elf -ramfs nanvix_rootfs.img -- python3.initrd
-
-# Windows
-.\bin\nanvixd.exe -ramfs nanvix_rootfs.img -- python3.initrd
-```
-
-The VM will boot, initialize CPython, take a snapshot into
-`snapshots/kernel.vmem` + `snapshots/kernel.whp.cbor`, and exit.
-
 ### Using Built-in Packages
 
 All pure Python packages are pre-installed. No `pip install` is needed:
@@ -104,7 +124,7 @@ All pure Python packages are pre-installed. No `pip install` is needed:
 ```bash
 # Place your script in the mnt/ directory
 echo 'import json; print(json.dumps({"hello": "nanvix"}))' > mnt/bootstrap.py
-./bin/nanvixd.elf -snapshot snapshots/kernel.whp.cbor -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd
+./bin/nanvixd.elf -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd
 ```
 
 ## Building from Source
@@ -128,6 +148,17 @@ cd nanvix-python
 ./z build      # Install pip packages and generate ramfs image
 ./z test       # Run smoke test and functional tests
 ./z release    # Package standalone runtime bundle into dist/
+```
+
+On Windows, `./z test` additionally runs a snapshot smoke test
+(`test-snapshot`) that cold-boots once to produce a WHP snapshot,
+then warm-restores from it to run a hello-world workload. Select
+individual targets with:
+
+```bash
+./z test -- test-smoke
+./z test -- test-snapshot      # Windows + standalone only
+./z test -- test-integration
 ```
 
 On Windows, use the PowerShell wrapper (`.\z.ps1`) or the


### PR DESCRIPTION
**Root cause:** WHP snapshots capture hardware-specific CPU state (registers, page tables) and are not portable across different machines. The CI-generated snapshots hang when restored on user machines with different CPU features.

**Fix:** Replace pre-built snapshot files with a \generate-snapshot.cmd\ script that users run once locally (~2s cold boot) to create snapshots matching their hardware.

**Changes:**
- Remove snapshot artifact upload from \windows-test\ job
- Remove snapshot download/inclusion from \windows-release\ job  
- \elease()\ still generates a snapshot for validation but doesn't bundle it
- Ships \generate-snapshot.cmd\ in the zip instead
- README updated to document the one-time local generation step