### PR TITLE
[build] Use GH_TOKEN for nanvix/cpython release downloads

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -851,7 +851,7 @@ class NanvixPythonBuild(ZScript):
         release = resolve_release(
             repo="nanvix/cpython",
             version_specifier=version_specifier,
-            gh_token=self.config.get("NANVIX_GH_TOKEN"),
+            gh_token=self.config.get("GH_TOKEN"),
         )
 
         asset_path = download_release_asset(
@@ -859,7 +859,7 @@ class NanvixPythonBuild(ZScript):
             version_specifier=version_specifier,
             asset_name=asset_name,
             dest=cache_dir,
-            gh_token=self.config.get("NANVIX_GH_TOKEN"),
+            gh_token=self.config.get("GH_TOKEN"),
             _release=release,
         )
 


### PR DESCRIPTION
## Summary

`_install_cpython()` in `.nanvix/z.py` was reading the GitHub token via
`self.config.get("NANVIX_GH_TOKEN")`, but neither CI nor `nanvix-zutil`
ever sets that key. CI exports `GH_TOKEN` (see `nanvix-ci.yml`'s Test
step: `GH_TOKEN: ${{ secrets.GH_TOKEN }}`), and `nanvix_zutil.config`
defines the canonical key as `CFG_GH_TOKEN = "GH_TOKEN"`.

As a result, `resolve_release()` and `download_release_asset()` always
received `gh_token=None` and issued unauthenticated requests to the
GitHub API. On shared CI runners this quickly exhausts the 60/hr
public IP rate limit, causing the cpython artifact download to fail:

```
error: Failed to fetch nanvix/cpython@3.12.3-nanvix-0.15.4: HTTP Error 403: rate limit exceeded
hint: Check your network connection or set GH_TOKEN.
```

## Fix

Switch both lookups in `_install_cpython()` to `"GH_TOKEN"` so the token
provided by CI (and by local users via the standard env var) is actually
used, lifting the limit to the authenticated 5000/hr quota.

## Reference

Observed in PR #230 — job run [26200421426](https://github.com/nanvix/nanvix-python/actions/runs/26200421426) (`ci / x86-microvm-standalone-256mb`).
