### PR TITLE
[ci] E: Update nanvix workflow refs to v2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
     with:
       zutil-version: "v0.10.3"
       platforms: '["microvm"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
     with:
-      zutil-version: "v0.10.3"
       platforms: '["microvm"]'
       process-modes: '["standalone"]'
       memory-sizes: '["256mb"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.1.0`](https://github.com/nanvix/workflows/releases/tag/v2.1.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.