### PR TITLE
ci: remove deprecated zutil-version parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,8 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
     with:
-      zutil-version: "v0.10.3"
       platforms: '["microvm"]'
       process-modes: '["standalone"]'
       memory-sizes: '["256mb"]'


### PR DESCRIPTION
Bumps the `nanvix/workflows` reusable workflow pin from `v2.0.2` to `v2.1.0` and drops the now-removed `zutil-version` input. The pinned zutil version is read from the `.zutils-version` file at the repo root.

Upstream: nanvix/workflows#91 / https://github.com/nanvix/workflows/releases/tag/v2.1.0