### PR TITLE
[ci] Sync zutils v0.10.4

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanvix-python"
 version = "3.12.3"
-nanvix-version = "0.16.6"
+nanvix-version = "0.16.7"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.10.4`](https://github.com/nanvix/zutils/releases/tag/v0.10.4):
- Pins `.zutils-version` to `v0.10.4` (source of truth on workflows@v2.1.0+).
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.16.7` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.