### PR TITLE
[ci] E: Pin nanvix to v0.16.32

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanvix-python"
 version = "3.12.3"
-nanvix-version = "0.16.17"
+nanvix-version = "0.16.32"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
## Summary

Bump pinned Nanvix version `0.16.17` → `0.16.32` in `.nanvix/nanvix.toml`.

This repo's per-config `release()` fix is already on the default branch, and all dependency releases at `-nanvix-0.16.32` now publish correct per-configuration assets, so dependency resolution and release packaging both work at the new version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
