### PR TITLE
fix(release): move staging from release to build

### DIFF
--- a/.nanvix/src/build.py
+++ b/.nanvix/src/build.py
@@ -18,11 +18,12 @@ import tarfile
 from pathlib import Path
 
 from nanvix_zutil import log, make_initrd
+from nanvix_zutil import paths
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
 from nanvix_zutil.helpers import InitRdArgs
 from nanvix_zutil.paths import nanvix_root, repo_root
 
-from .lib import LibMixin, mkramfs_binary
+from .lib import LibMixin, mkramfs_binary, nanvixd_binary
 
 
 class BuildMixin(LibMixin):
@@ -613,6 +614,193 @@ class BuildMixin(LibMixin):
         for t in (tests_dir / "func").glob("test_*.py"):
             shutil.copy2(t, sysroot)
 
+    def _stage_release(self) -> None:
+        sysroot = self._sysroot_path()
+        nanvixd_name = nanvixd_binary()
+        mode = self.config.deployment_mode
+        platform_name = self.config.machine
+        asset_prefix = self._asset_prefix()
+        bundle_dir = paths.release_dir()
+
+        if not (sysroot / "bin" / nanvixd_name).is_file():
+            log.fatal(
+                f"{nanvixd_name} not found in sysroot.",
+                code=EXIT_MISSING_DEP,
+            )
+        if not (sysroot / "bin" / "python3.12").is_file():
+            log.fatal(
+                "python3.12 not found in sysroot.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z build` first.",
+            )
+
+        log.info(f"release: staging artifacts for {asset_prefix}")
+
+        if bundle_dir.exists():
+            shutil.rmtree(bundle_dir)
+        bundle_dir.mkdir(parents=True)
+
+        # Copy runtime binaries
+        log.info("release: copying runtime binaries")
+        bin_dir = bundle_dir / "bin"
+        bin_dir.mkdir()
+        runtime_bins = [nanvixd_name, "kernel.elf", "python3.12"]
+        if mode == "multi-process":
+            runtime_bins.extend(["linuxd.elf", "uservm.elf"])
+        for name in runtime_bins:
+            src_file = sysroot / "bin" / name
+            if src_file.is_file():
+                shutil.copy2(src_file, bin_dir)
+        python_target = bin_dir / "python3.12"
+        python_link = bin_dir / "python3"
+        if python_target.is_file():
+            try:
+                python_link.symlink_to("python3.12")
+            except OSError:
+                shutil.copy2(python_target, python_link)
+
+        # Copy Python stdlib + site-packages
+        log.info("release: copying Python standard library and site-packages")
+        lib_dir = bundle_dir / "lib"
+        lib_dir.mkdir()
+        pylib = sysroot / "lib" / "python3.12"
+        if pylib.is_dir():
+            shutil.copytree(pylib, lib_dir / "python3.12")
+
+        # Linker script
+        user_ld = sysroot / "lib" / "user.ld"
+        if user_ld.is_file():
+            shutil.copy2(user_ld, lib_dir)
+
+        # Clean build/test artifacts from bundle
+        log.info("release: cleaning build and test artifacts")
+        for p in bundle_dir.glob("test_*.py"):
+            p.unlink()
+        smoke = bundle_dir / "smoke_test_l2.py"
+        smoke.unlink(missing_ok=True)
+        for d in ("logs", "__pycache__"):
+            p = bundle_dir / d
+            if p.is_dir():
+                shutil.rmtree(p)
+
+        # Precompile .py to .pyc
+        log.info("release: pre-compiling .pyc bytecode cache")
+        host_python = self._host_python()
+        if host_python:
+            subprocess.run(
+                [host_python, "-m", "compileall", "-q", str(lib_dir / "python3.12")],
+                capture_output=True,
+            )
+
+        # Build and include ramfs image for standalone mode
+        if mode == "standalone":
+            mkramfs = sysroot / "bin" / mkramfs_binary()
+            if not mkramfs.is_file():
+                log.fatal(
+                    f"{mkramfs_binary()} not found (required for standalone mode).",
+                    code=EXIT_MISSING_DEP,
+                    hint="Run `./z setup` first.",
+                )
+            log.info("release: validating ramfs image")
+            try:
+                # Install _boot.py into sysroot and validate the ramfs
+                # (built earlier by ``./z build``; ``_ensure_ramfs``
+                # never rebuilds and hard-fails if missing/stale).
+                self._install_boot_script(sysroot)
+                self._ensure_ramfs(sysroot)
+                if self._ramfs_img and self._ramfs_img.is_file():
+                    shutil.copy2(self._ramfs_img, bundle_dir / "nanvix_rootfs.img")
+                else:
+                    log.fatal(
+                        "ramfs image not found after build.",
+                        code=EXIT_BUILD_FAILURE,
+                        hint="Ensure `./z build` completed successfully.",
+                    )
+
+                # Build multi-binary initrd with _boot.py as entry point
+                log.info("release: building python3.initrd")
+                initrd = self._ensure_initrd(sysroot)
+                shutil.copy2(initrd, bundle_dir / "python3.initrd")
+
+                # Create mnt/ directory for user workloads
+                (bundle_dir / "mnt").mkdir(exist_ok=True)
+
+            finally:
+                self._cleanup_ramfs()
+                self._cleanup_initrd()
+
+        # README
+        if mode == "standalone":
+            cold_cmd = (
+                f"./bin/{nanvixd_name} -ramfs nanvix_rootfs.img"
+                f" -mount ./mnt -- python3.initrd"
+            )
+            readme_text = (
+                f"# Nanvix Python Runtime\n\n"
+                f"Platform: {platform_name}\n"
+                f"Process mode: {mode}\n\n"
+                f"## Quick Start (cold boot)\n\n"
+                f"After extracting the archive, enter the directory and run:\n\n"
+                f"```sh\n"
+                f"cd {asset_prefix}\n"
+                f"{cold_cmd}\n"
+                f"```\n\n"
+                f"On startup CPython executes `/mnt/bootstrap.py` if present,\n"
+                f"otherwise it drops into an interactive REPL.\n\n"
+                f"## Running Your Own Script\n\n"
+                f"Place a `bootstrap.py` in a directory and mount it:\n\n"
+                f"```sh\n"
+                f"echo 'print(\"Hello from Nanvix!\")' > mnt/bootstrap.py\n"
+                f"{cold_cmd}\n"
+                f"```\n"
+            )
+        else:
+            run_cmd = f"./bin/{nanvixd_name} -- ./bin/python3.12"
+            readme_text = (
+                f"# Nanvix Python Runtime\n\n"
+                f"Platform: {platform_name}\n"
+                f"Process mode: {mode}\n\n"
+                f"## Quick Start\n\n"
+                f"After extracting the archive, enter the directory and run:\n\n"
+                f"```sh\n"
+                f"cd {asset_prefix}\n"
+                f"{run_cmd} script.py\n"
+                f"```\n"
+            )
+        (bundle_dir / "README.md").write_text(readme_text)
+
+        # Validate staged bundle
+        log.info("release: validating staged bundle")
+        required = [
+            f"bin/{nanvixd_name}",
+            "bin/kernel.elf",
+            "bin/python3.12",
+        ]
+        if mode == "standalone":
+            required.extend(
+                [
+                    "nanvix_rootfs.img",
+                    "python3.initrd",
+                ]
+            )
+        else:
+            required.extend(
+                [
+                    "lib/python3.12/os.py",
+                    "lib/python3.12/site.py",
+                ]
+            )
+        if mode == "multi-process":
+            required.extend(["bin/linuxd.elf", "bin/uservm.elf"])
+        missing = [f for f in required if not (bundle_dir / f).is_file()]
+        if missing:
+            log.fatal(
+                "bundle validation failed \u2014 missing files:\n"
+                + "\n".join(f"  {f}" for f in missing),
+                code=EXIT_BUILD_FAILURE,
+            )
+        log.success("release: staging complete")
+
     # ------------------------------------------------------------------
     # Lifecycle entry point
     # ------------------------------------------------------------------
@@ -653,5 +841,7 @@ class BuildMixin(LibMixin):
 
             # Build the multi-binary initrd with _boot.py as entry point
             self._ensure_initrd(sysroot)
+
+        self._stage_release()
 
         log.success("build complete")

--- a/.nanvix/src/clean.py
+++ b/.nanvix/src/clean.py
@@ -19,13 +19,13 @@ class CleanMixin(LibMixin):
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        # Clean release assets
-        dist_dir = paths.dist_dir()
-        if dist_dir.is_dir():
-            shutil.rmtree(dist_dir)
-        release_dir = repo_root() / "release-assets"
-        if release_dir.is_dir():
-            shutil.rmtree(release_dir)
+        # Clean release assets (staged tree + dist archives)
+        for d in (paths.release_dir(), paths.dist_dir()):
+            if d.is_dir():
+                shutil.rmtree(d)
+        legacy_release = repo_root() / "release-assets"
+        if legacy_release.is_dir():
+            shutil.rmtree(legacy_release)
 
         # Clean ramfs artifacts
         self._cleanup_ramfs()

--- a/.nanvix/src/lib.py
+++ b/.nanvix/src/lib.py
@@ -149,6 +149,12 @@ class LibMixin(ZScript):
                 except subprocess.TimeoutExpired:
                     fh.write(f"\nTIMEOUT after {timeout}s\n")
 
+    def _asset_prefix(self) -> str:
+        """Return the platform/mode/memory triple used for archive names."""
+        return (
+            f"{self.config.machine}-{self.config.deployment_mode}"
+            f"-{self.config.memory_size}"
+        )
     # ------------------------------------------------------------------
     # Forward declarations — concrete implementations live in BuildMixin.
     # Declared here so basedpyright resolves cross-mixin self.<helper>()

--- a/.nanvix/src/release.py
+++ b/.nanvix/src/release.py
@@ -10,210 +10,35 @@ import subprocess
 import zipfile
 
 from nanvix_zutil import log, paths
-from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
-from nanvix_zutil.paths import nanvix_root, repo_root
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.paths import repo_root
 
-from .lib import IS_WINDOWS, LibMixin, mkramfs_binary, nanvixd_binary
+from .lib import IS_WINDOWS, LibMixin
 
 
 class ReleaseMixin(LibMixin):
-    """``./z release`` — package the runtime bundle for distribution."""
+    """``./z release`` — archive the runtime bundle for distribution.
+
+    The bundle tree is populated during ``./z build`` (see
+    ``BuildMixin._stage_release``) under ``paths.release_dir()``;
+    ``release`` only compresses that tree into ``paths.dist_dir()``.
+    """
 
     def release(self) -> None:
-        """Package the runtime bundle for distribution."""
         sysroot = self._sysroot_path()
+        bundle_dir = paths.release_dir()
+        dist_dir = paths.dist_dir()
+        asset_prefix = self._asset_prefix()
 
-        nanvixd_name = nanvixd_binary()
-        if not (sysroot / "bin" / nanvixd_name).is_file():
+        if not bundle_dir.is_dir():
             log.fatal(
-                f"{nanvixd_name} not found in sysroot.",
-                code=EXIT_MISSING_DEP,
-            )
-        if not (sysroot / "bin" / "python3.12").is_file():
-            log.fatal(
-                "python3.12 not found in sysroot.",
+                f"staged release tree not found at {bundle_dir}.",
                 code=EXIT_MISSING_DEP,
                 hint="Run `./z build` first.",
             )
 
-        platform_name = self.config.machine
-        mode = self.config.deployment_mode
-        memory = self.config.memory_size
-        asset_prefix = f"{platform_name}-{mode}-{memory}"
-
-        dist_dir = paths.dist_dir()
-        bundle_root = nanvix_root() / "release-bundle"
-        bundle_dir = bundle_root / asset_prefix
-
-        log.info(f"release: preparing artifacts for {asset_prefix}")
-
-        if bundle_root.exists():
-            shutil.rmtree(bundle_root)
         dist_dir.mkdir(parents=True, exist_ok=True)
-        bundle_dir.mkdir(parents=True)
 
-        # Copy runtime binaries
-        log.info("release: copying runtime binaries")
-        bin_dir = bundle_dir / "bin"
-        bin_dir.mkdir()
-        runtime_bins = [nanvixd_name, "kernel.elf", "python3.12"]
-        if mode == "multi-process":
-            runtime_bins.extend(["linuxd.elf", "uservm.elf"])
-        for name in runtime_bins:
-            src_file = sysroot / "bin" / name
-            if src_file.is_file():
-                shutil.copy2(src_file, bin_dir)
-        python_target = bin_dir / "python3.12"
-        python_link = bin_dir / "python3"
-        if python_target.is_file():
-            try:
-                python_link.symlink_to("python3.12")
-            except OSError:
-                shutil.copy2(python_target, python_link)
-
-        # Copy Python stdlib + site-packages
-        log.info("release: copying Python standard library and site-packages")
-        lib_dir = bundle_dir / "lib"
-        lib_dir.mkdir()
-        pylib = sysroot / "lib" / "python3.12"
-        if pylib.is_dir():
-            shutil.copytree(pylib, lib_dir / "python3.12")
-
-        # Linker script
-        user_ld = sysroot / "lib" / "user.ld"
-        if user_ld.is_file():
-            shutil.copy2(user_ld, lib_dir)
-
-        # Clean build/test artifacts from bundle
-        log.info("release: cleaning build and test artifacts")
-        for p in bundle_dir.glob("test_*.py"):
-            p.unlink()
-        smoke = bundle_dir / "smoke_test_l2.py"
-        smoke.unlink(missing_ok=True)
-        for d in ("logs", "__pycache__"):
-            p = bundle_dir / d
-            if p.is_dir():
-                shutil.rmtree(p)
-
-        # Precompile .py to .pyc
-        log.info("release: pre-compiling .pyc bytecode cache")
-        host_python = self._host_python()
-        if host_python:
-            subprocess.run(
-                [host_python, "-m", "compileall", "-q", str(lib_dir / "python3.12")],
-                capture_output=True,
-            )
-
-        # Build and include ramfs image for standalone mode
-        if mode == "standalone":
-            mkramfs = sysroot / "bin" / mkramfs_binary()
-            if not mkramfs.is_file():
-                log.fatal(
-                    f"{mkramfs_binary()} not found (required for standalone mode).",
-                    code=EXIT_MISSING_DEP,
-                    hint="Run `./z setup` first.",
-                )
-            log.info("release: validating ramfs image")
-            try:
-                # Install _boot.py into sysroot and validate the ramfs
-                # (built earlier by ``./z build``; ``_ensure_ramfs``
-                # never rebuilds and hard-fails if missing/stale).
-                self._install_boot_script(sysroot)
-                self._ensure_ramfs(sysroot)
-                if self._ramfs_img and self._ramfs_img.is_file():
-                    shutil.copy2(self._ramfs_img, bundle_dir / "nanvix_rootfs.img")
-                else:
-                    log.fatal(
-                        "ramfs image not found after build.",
-                        code=EXIT_BUILD_FAILURE,
-                        hint="Ensure `./z build` completed successfully.",
-                    )
-
-                # Build multi-binary initrd with _boot.py as entry point
-                log.info("release: building python3.initrd")
-                initrd = self._ensure_initrd(sysroot)
-                shutil.copy2(initrd, bundle_dir / "python3.initrd")
-
-                # Create mnt/ directory for user workloads
-                (bundle_dir / "mnt").mkdir(exist_ok=True)
-
-            finally:
-                self._cleanup_ramfs()
-                self._cleanup_initrd()
-
-        # README
-        if mode == "standalone":
-            cold_cmd = (
-                f"./bin/{nanvixd_name} -ramfs nanvix_rootfs.img"
-                f" -mount ./mnt -- python3.initrd"
-            )
-            readme_text = (
-                f"# Nanvix Python Runtime\n\n"
-                f"Platform: {platform_name}\n"
-                f"Process mode: {mode}\n\n"
-                f"## Quick Start (cold boot)\n\n"
-                f"After extracting the archive, enter the directory and run:\n\n"
-                f"```sh\n"
-                f"cd {asset_prefix}\n"
-                f"{cold_cmd}\n"
-                f"```\n\n"
-                f"On startup CPython executes `/mnt/bootstrap.py` if present,\n"
-                f"otherwise it drops into an interactive REPL.\n\n"
-                f"## Running Your Own Script\n\n"
-                f"Place a `bootstrap.py` in a directory and mount it:\n\n"
-                f"```sh\n"
-                f"echo 'print(\"Hello from Nanvix!\")' > mnt/bootstrap.py\n"
-                f"{cold_cmd}\n"
-                f"```\n"
-            )
-        else:
-            run_cmd = f"./bin/{nanvixd_name} -- ./bin/python3.12"
-            readme_text = (
-                f"# Nanvix Python Runtime\n\n"
-                f"Platform: {platform_name}\n"
-                f"Process mode: {mode}\n\n"
-                f"## Quick Start\n\n"
-                f"After extracting the archive, enter the directory and run:\n\n"
-                f"```sh\n"
-                f"cd {asset_prefix}\n"
-                f"{run_cmd} script.py\n"
-                f"```\n"
-            )
-        (bundle_dir / "README.md").write_text(readme_text)
-
-        # Validate bundle
-        log.info("release: validating bundle")
-        required = [
-            f"bin/{nanvixd_name}",
-            "bin/kernel.elf",
-            "bin/python3.12",
-        ]
-        if mode == "standalone":
-            required.extend(
-                [
-                    "nanvix_rootfs.img",
-                    "python3.initrd",
-                ]
-            )
-        else:
-            required.extend(
-                [
-                    "lib/python3.12/os.py",
-                    "lib/python3.12/site.py",
-                ]
-            )
-        if mode == "multi-process":
-            required.extend(["bin/linuxd.elf", "bin/uservm.elf"])
-        missing = [f for f in required if not (bundle_dir / f).is_file()]
-        if missing:
-            log.fatal(
-                "bundle validation failed \u2014 missing files:\n"
-                + "\n".join(f"  {f}" for f in missing),
-                code=EXIT_BUILD_FAILURE,
-            )
-        log.success("release: validation passed")
-
-        # Create archive (.zip on Windows, .tar.gz on non-Windows hosts)
         if IS_WINDOWS:
             log.info("release: creating zip archive")
             archive = dist_dir / f"{asset_prefix}.zip"
@@ -228,10 +53,17 @@ class ReleaseMixin(LibMixin):
             log.info("release: creating tarball")
             archive = dist_dir / f"{asset_prefix}.tar.gz"
             subprocess.run(
-                ["tar", "-czf", str(archive), "-C", str(bundle_root), asset_prefix],
+                [
+                    "tar",
+                    "-czf",
+                    str(archive),
+                    "-C",
+                    str(bundle_dir.parent),
+                    f"--transform=s,^{bundle_dir.name},{asset_prefix},",
+                    bundle_dir.name,
+                ],
                 check=True,
             )
-        shutil.rmtree(bundle_root)
 
         # Expose ELF binaries in a visible directory so that CI artifact
         # upload globs (e.g. **/*.elf) can find them — hidden directories


### PR DESCRIPTION
Closes #303.

Stacked on top of #302.

Extracts the bundle-staging logic out of `release` and into a new
`BuildMixin._stage_release` helper called at the end of `build`.
`release` now only archives the already-staged tree at
`paths.release_dir()` into `paths.dist_dir()`.

The staged tree persists after `release`; `clean` is updated to remove
it alongside the dist archives and the legacy `release-assets`
directory.

Mirrors the cpython split.

### Behavior notes

- Bundle validation now runs at build time rather than release time.
  CI flows that ship the staged tree between jobs should be aware.
- Running `./z release` no longer re-stages on every invocation; a
  stale `out/release/` from a prior build will be re-archived.

Followed up by #306 