### PR TITLE
[ci] E: Update nanvix workflow refs to v2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.3.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.4.0
     with:
       platforms: '["microvm"]'
       process-modes: '["standalone"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.4.0`](https://github.com/nanvix/workflows/releases/tag/v2.4.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.