### PR TITLE
[python] Migrate distribution to Nanvix SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       yaml-paths: ".github/workflows/ci.yml"
       release-notes-extra: |
         CPython 3.12.3 distribution for Nanvix with pure Python pip packages.
-      docker-image: "ghcr.io/nanvix/toolchain-python@sha256:2ef7213bfff85e927f18d8f0fc53063b9c6ffed236a6b30c92f6b4e148c2dec4" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f" # yamllint disable-line rule:line-length
       test-output-globs: '["nanvix_rootfs.img"]'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanvix-python"
 version = "3.12.3"
-nanvix-version = "0.17.9"
+nanvix-version = "0.20.0"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/src/benchmark.py
+++ b/.nanvix/src/benchmark.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import tempfile
 import time
 from pathlib import Path
 
@@ -56,7 +55,7 @@ class BenchmarkMixin(LibMixin):
             initrd = self._ensure_initrd(sysroot)
 
             # Create a temp mount directory with a hello-world bootstrap.py
-            mount_dir = Path(tempfile.mkdtemp(prefix="nanvix-bench-"))
+            mount_dir = self._temporary_directory("nanvix-bench-")
             (mount_dir / "bootstrap.py").write_text('print("hello")\n')
             cmd = [
                 nanvixd_bin,
@@ -77,7 +76,7 @@ class BenchmarkMixin(LibMixin):
                 '-c print("hello")',
             ]
 
-        tmp = Path(tempfile.gettempdir())
+        tmp = self._log_directory()
         log_file = tmp / "benchmark.log"
 
         log.info("running benchmark: hello world")

--- a/.nanvix/src/build.py
+++ b/.nanvix/src/build.py
@@ -4,7 +4,7 @@
 """Build lifecycle for the nanvix-python ZScript.
 
 Owns ramfs/initrd construction, site-packages installation, the PIL shim,
-the openpyxl lxml patch, and the standalone-mode Docker-based .pyc
+the openpyxl lxml patch, and the standalone-mode SDK-based .pyc
 pre-compilation pipeline.
 """
 
@@ -24,7 +24,7 @@ from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
 from nanvix_zutil.helpers import InitRdArgs
 from nanvix_zutil.paths import nanvix_root, repo_root, test_out
 
-from .lib import LibMixin, mkramfs_binary, nanvixd_binary
+from .lib import SDK_IMAGE, LibMixin, mkramfs_binary, nanvixd_binary
 
 
 class BuildMixin(LibMixin):
@@ -84,7 +84,7 @@ class BuildMixin(LibMixin):
         """Validate that an up-to-date ramfs image exists.
 
         Used by ``test``, ``release``, and ``benchmark``: never builds. Building
-        the ramfs requires Docker (for .pyc pre-compilation) and is therefore
+        the ramfs requires the SDK (for .pyc pre-compilation) and is therefore
         confined to ``./z build`` via :meth:`_build_ramfs`. A missing or stale
         image is fatal. In CI, this short-circuits if the expected ramfs image
         is found.
@@ -111,7 +111,7 @@ class BuildMixin(LibMixin):
             log.fatal(
                 "ramfs image missing or stale.",
                 code=EXIT_MISSING_DEP,
-                hint="Run `./z build` first (requires Docker).",
+                hint="Run `./z build` first (requires Docker and the pinned SDK).",
             )
 
         self._ramfs_img = img
@@ -120,7 +120,7 @@ class BuildMixin(LibMixin):
     def _build_ramfs(self, sysroot: Path) -> Path:
         """Build (or reuse) a ramfs image for standalone mode.
 
-        Only ``./z build`` may call this: it invokes Docker via
+        Only ``./z build`` may call this: it invokes the SDK via
         :meth:`_precompile_pyc` and is the sole producer of the ramfs.
         """
         if self._ramfs_img and self._ramfs_img.is_file():
@@ -154,7 +154,7 @@ class BuildMixin(LibMixin):
             shutil.copy2(src, stripped_root)
 
         # _boot.pyc is compiled inside _create_stripped_sysroot via
-        # Docker (Python 3.12) and placed at the sysroot root.
+        # the SDK's host Python 3.12 and placed at the sysroot root.
 
         # Generate build manifests for post-build inspection
         self._write_build_manifests(sysroot, stripped, nanvix_root())
@@ -314,7 +314,7 @@ class BuildMixin(LibMixin):
 
         # Remove native/build source from site-packages
         for ext in ("*.pyx", "*.pxd", "*.c", "*.h", "*.cpp"):
-            for f in site_pkg.rglob(ext):
+            for f in pylib.rglob(ext):
                 f.unlink(missing_ok=True)
 
         # Remove non-Python assets that are dead weight at runtime
@@ -343,7 +343,7 @@ class BuildMixin(LibMixin):
                 for f in docutils_pkg.rglob(ext):
                     f.unlink(missing_ok=True)
 
-        # Pre-compile .py → .pyc using Docker toolchain (Python 3.12)
+        # Pre-compile .py → .pyc using the SDK host Python 3.12
         # then strip .py sources so ramfs ships only bytecode.
         #
         # Place _boot.py inside pylib so it's compiled with the correct
@@ -367,22 +367,22 @@ class BuildMixin(LibMixin):
         if boot_pyc_in_pylib.is_file():
             shutil.move(str(boot_pyc_in_pylib), str(root / "_boot.pyc"))
 
-    def _precompile_pyc(self, pylib: Path) -> None:
-        """Pre-compile .py to .pyc using Docker toolchain's Python 3.12.
+    def _precompile_pyc(
+        self,
+        pylib: Path,
+        *,
+        legacy: bool = True,
+        strip_sources: bool = True,
+    ) -> None:
+        """Pre-compile .py to .pyc using the pinned SDK's host Python 3.12.
 
-        Uses ``compileall -b`` to write .pyc alongside sources, then
-        removes .py files.  To avoid slow volume-mount I/O on Windows,
-        the directory is tarred into the container and extracted back.
+        The directory is tarred into the container and extracted back to
+        avoid slow volume-mount I/O on Windows.
 
-        Hard-fails if Docker is unavailable: the standalone ramfs ships
-        .pyc-only contents (including ``/sysroot/_boot.pyc``), so a
-        Docker-less build would produce an unusable image.  This is
-        only reachable from ``./z build`` via :meth:`_build_ramfs`;
-        ``test``/``release``/``benchmark`` go through
-        :meth:`_ensure_ramfs` and never reach here.
+        Hard-fails if Docker is unavailable. The standalone ramfs ships
+        sourceless bytecode, while release bundles retain sources alongside
+        an opt-0 bytecode cache.
         """
-        _DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-python:latest"
-
         if shutil.which("docker") is None:
             log.fatal(
                 "Docker is required to build the standalone ramfs "
@@ -391,14 +391,20 @@ class BuildMixin(LibMixin):
                 hint="Install Docker and rerun `./z build`.",
             )
 
-        log.info("pre-compiling .py to .pyc via Docker (Python 3.12)")
+        log.info("pre-compiling .py to .pyc with SDK host Python 3.12")
 
-        container_work = "/tmp/pylib"
+        container_work = "/work/pylib"
+        compile_flags = "-b " if legacy else ""
+        delete_sources = (
+            f"find {container_work} -name '*.py' -delete && " if strip_sources else ""
+        )
+        optimize = "-O " if strip_sources else ""
         script = (
             f"mkdir -p {container_work} && "
             f"tar -xf - -C {container_work} && "
-            f"python3 -O -m compileall -b -q {container_work} && "
-            f"find {container_work} -name '*.py' -delete && "
+            f"/usr/bin/python3 {optimize}-m compileall "
+            f"{compile_flags}-q {container_work} && "
+            f"{delete_sources}"
             f"tar -cf - -C {container_work} ."
         )
 
@@ -416,7 +422,7 @@ class BuildMixin(LibMixin):
             "run",
             "--rm",
             "-i",
-            _DOCKER_IMAGE,
+            SDK_IMAGE,
             "sh",
             "-c",
             script,
@@ -428,7 +434,7 @@ class BuildMixin(LibMixin):
         )
         if result.returncode != 0:
             log.fatal(
-                "Docker compileall failed (rc="
+                "SDK compileall failed (rc="
                 f"{result.returncode}): {result.stderr.decode(errors='replace').strip()}",
                 code=EXIT_BUILD_FAILURE,
                 hint="Inspect the Docker output above and rerun `./z build`.",
@@ -443,15 +449,16 @@ class BuildMixin(LibMixin):
 
         # Validate that the entry-point bytecode was produced; without
         # it the standalone initrd cannot warm-start.
-        if not (pylib / "_boot.pyc").is_file():
+        if legacy and strip_sources and not (pylib / "_boot.pyc").is_file():
             log.fatal(
-                "Docker compileall did not produce _boot.pyc",
+                "SDK compileall did not produce _boot.pyc",
                 code=EXIT_BUILD_FAILURE,
                 hint="Inspect the Docker output above and rerun `./z build`.",
             )
 
         count = sum(1 for _ in pylib.rglob("*.pyc"))
-        log.info(f"pre-compiled {count} .pyc files (source .py removed)")
+        suffix = " (source .py removed)" if strip_sources else ""
+        log.info(f"pre-compiled {count} .pyc files{suffix}")
 
     def _cleanup_ramfs(self) -> None:
         """Remove intermediate ramfs build artifacts (keeps cached image)."""
@@ -549,6 +556,7 @@ class BuildMixin(LibMixin):
         req_hash = h.hexdigest()
 
         if sentinel.is_file() and sentinel.read_text().strip() == req_hash:
+            self._remove_site_package_build_artifacts(site_pkg)
             log.info("site-packages already up-to-date, skipping pip install")
             return
 
@@ -574,7 +582,15 @@ class BuildMixin(LibMixin):
         pth = site_pkg / "distutils-precedence.pth"
         pth.unlink(missing_ok=True)
 
+        self._remove_site_package_build_artifacts(site_pkg)
         sentinel.write_text(req_hash)
+
+    @staticmethod
+    def _remove_site_package_build_artifacts(site_pkg: Path) -> None:
+        """Remove native build inputs that are not usable at runtime."""
+        for pattern in ("*.a", "*.c", "*.cpp", "*.h", "*.pxd", "*.pyx"):
+            for path in site_pkg.rglob(pattern):
+                path.unlink(missing_ok=True)
 
     def _install_pil_shim(self, site_pkg: Path) -> None:
         """Copy the pure-Python PIL shim into site-packages.
@@ -675,11 +691,6 @@ class BuildMixin(LibMixin):
         if pylib.is_dir():
             shutil.copytree(pylib, lib_dir / "python3.12")
 
-        # Linker script
-        user_ld = sysroot / "lib" / "user.ld"
-        if user_ld.is_file():
-            shutil.copy2(user_ld, lib_dir)
-
         # Clean build/test artifacts from bundle
         log.info("release: cleaning build and test artifacts")
         for p in bundle_dir.glob("test_*.py"):
@@ -693,12 +704,11 @@ class BuildMixin(LibMixin):
 
         # Precompile .py to .pyc
         log.info("release: pre-compiling .pyc bytecode cache")
-        host_python = self._host_python()
-        if host_python:
-            subprocess.run(
-                [host_python, "-m", "compileall", "-q", str(lib_dir / "python3.12")],
-                capture_output=True,
-            )
+        self._precompile_pyc(
+            lib_dir / "python3.12",
+            legacy=False,
+            strip_sources=False,
+        )
 
         # Build and include ramfs image for standalone mode
         if mode == "standalone":

--- a/.nanvix/src/lib.py
+++ b/.nanvix/src/lib.py
@@ -17,13 +17,15 @@ import sys
 import tempfile
 from pathlib import Path
 
-from nanvix_zutil import CFG_SYSROOT, TOOLCHAIN_CONTAINER_PATH, ZScript, log
+from nanvix_zutil import CFG_SYSROOT, ZScript, log
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.paths import test_out
 
 __all__ = (
     "DEFAULT_TIMEOUT",
     "IS_WINDOWS",
     "LibMixin",
+    "SDK_IMAGE",
     "mkramfs_binary",
     "nanvixd_binary",
 )
@@ -32,6 +34,11 @@ __all__ = (
 DEFAULT_TIMEOUT = 300
 
 IS_WINDOWS = sys.platform == "win32"
+
+SDK_IMAGE = (
+    "ghcr.io/nanvix/nanvix-sdk-c-clang"
+    "@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+)
 
 
 def nanvixd_binary() -> str:
@@ -46,6 +53,20 @@ def mkramfs_binary() -> str:
 
 class LibMixin(ZScript):
     """Shared state + helpers for nanvix-python lifecycle mixins."""
+
+    # The downloaded sysroot is runtime-only. Build-time headers, libraries,
+    # startup objects, and linker scripts live exclusively in the SDK.
+    SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
+        "bin/nanvixd.elf",
+        "bin/kernel.elf",
+        "bin/mkramfs.elf",
+    )
+    SYSROOT_REQUIRED_FILES_WINDOWS: tuple[str, ...] = (
+        "bin/nanvixd.exe",
+        "bin/kernel.elf",
+        "bin/mkramfs.exe",
+    )
+    SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = ()
 
     # Standalone / ramfs artefacts shared across build and test stages.
     _ramfs_img: Path | None = None
@@ -62,17 +83,19 @@ class LibMixin(ZScript):
             )
         return Path(sysroot)
 
-    def _toolchain_str(self) -> str:
-        return str(TOOLCHAIN_CONTAINER_PATH)
+    @staticmethod
+    def _temporary_directory(prefix: str) -> Path:
+        """Create a temporary directory under the ignored test output."""
+        temp_root = test_out() / "temp"
+        temp_root.mkdir(parents=True, exist_ok=True)
+        return Path(tempfile.mkdtemp(prefix=prefix, dir=temp_root))
 
-    def _host_python(self) -> str | None:
-        toolchain_python = Path(self._toolchain_str()) / "bin" / "python3"
-        if toolchain_python.is_file():
-            return str(toolchain_python)
-        for name in ("python3", "python"):
-            if shutil.which(name):
-                return name
-        return None
+    @staticmethod
+    def _log_directory() -> Path:
+        """Return the ignored directory used for transient command logs."""
+        logs = test_out() / "logs"
+        logs.mkdir(parents=True, exist_ok=True)
+        return logs
 
     def _nanvix_run(
         self,
@@ -97,7 +120,7 @@ class LibMixin(ZScript):
                     hint="Run `./z build` first.",
                 )
             initrd = self._ensure_initrd(sysroot)
-            mount_dir = Path(tempfile.mkdtemp(prefix="nanvix-mount-"))
+            mount_dir = self._temporary_directory("nanvix-mount-")
             (mount_dir / "argv.txt").write_text(f"/sysroot/{script_path}\n")
             cmd = [
                 nanvixd,
@@ -190,4 +213,13 @@ class LibMixin(ZScript):
         raise NotImplementedError
 
     def _stage_test_scripts(self, sysroot: Path) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def _precompile_pyc(
+        self,
+        pylib: Path,
+        *,
+        legacy: bool = True,
+        strip_sources: bool = True,
+    ) -> None:  # pragma: no cover
         raise NotImplementedError

--- a/.nanvix/src/setup.py
+++ b/.nanvix/src/setup.py
@@ -5,94 +5,185 @@
 
 from __future__ import annotations
 
+import shutil
 import tarfile
-from pathlib import Path
+import zipfile
+from pathlib import Path, PurePosixPath
 
-from nanvix_zutil import log
-from nanvix_zutil.github import download_release_asset, resolve_release
+from nanvix_zutil import Dependency, log
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 from nanvix_zutil.paths import nanvix_root
 
 from .lib import LibMixin
 
 
 class SetupMixin(LibMixin):
-    """``./z setup`` — download sysroot and pre-built CPython buildroot."""
+    """``./z setup`` — download the runtime and pre-built CPython."""
 
     def setup(self) -> bool:
-        """Download sysroot and pre-built CPython buildroot.
+        """Download the sysroot and pre-built CPython.
 
         The base ``super().setup()`` downloads the Nanvix sysroot and
-        resolves dependencies declared in ``nanvix.toml``. Then we
-        download the pre-built CPython release artifact and extract the
-        interpreter binary and standard library into the sysroot.
+        resolves and caches dependencies declared in ``nanvix.toml``. Then
+        we reuse the cached CPython runtime artifact and extract only the
+        interpreter binary and standard library into the runtime sysroot.
         """
+        dependency = self._cpython_dependency()
+        # Include the extension so prefix matching cannot select either the
+        # similarly named buildroot archive or the Windows delivery bundle
+        # (which contains a ready-made ramfs rather than an extractable stdlib).
+        dependency.artifact_pattern = "{name}-{machine}-{mode}-{mem}.tar.gz"
         result = super().setup()
 
         sysroot = self._sysroot_path()
-        self._install_cpython(sysroot)
+        self._install_cpython(sysroot, dependency)
 
         log.success("setup complete")
         return result
 
-    def _install_cpython(self, sysroot: Path) -> None:
-        """Download and extract the pre-built CPython artifact into sysroot."""
-        machine = self.config.machine
-        mode = self.config.deployment_mode
-        memory = self.config.memory_size
+    def _cpython_dependency(self) -> Dependency:
+        """Return the CPython dependency parsed and resolved by zutils."""
+        dependency = next(
+            (dep for dep in self.manifest.dependencies if dep.name == "cpython"),
+            None,
+        )
+        if dependency is None:
+            log.fatal(
+                "cpython is not declared in nanvix.toml.",
+                code=EXIT_MISSING_DEP,
+            )
+        return dependency
 
-        # Resolve the cpython version (suffixed with nanvix sysroot version)
-        cpython_version = self.manifest.version
-        sysroot_tag = self.config.get("sysroot_tag", "")
-        nanvix_ver = sysroot_tag.removeprefix("v") if sysroot_tag else ""
-        if sysroot_tag:
-            version_specifier = f"{cpython_version}-nanvix-{nanvix_ver}"
-        else:
-            version_specifier = cpython_version
-
-        asset_name = f"cpython-{machine}-{mode}-{memory}.tar.gz"
+    def _cached_cpython_artifact(self, dependency: Dependency) -> Path:
+        """Return the CPython runtime artifact downloaded by base setup."""
+        prefix = dependency.artifact_pattern.format(
+            name=dependency.name,
+            machine=self.config.machine,
+            mode=self.config.deployment_mode,
+            mem=self.config.memory_size,
+        )
         cache_dir = nanvix_root() / "cache"
+        candidates = [
+            path
+            for path in cache_dir.iterdir()
+            if path.is_file()
+            and path.name.startswith(prefix)
+            and path.name.endswith((".tar.bz2", ".tar.gz", ".zip"))
+        ]
+        if not candidates:
+            log.fatal(
+                f"base setup did not cache a CPython artifact matching '{prefix}'.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` again and inspect the dependency download.",
+            )
+        candidates.sort(
+            key=lambda path: (path.stat().st_mtime, path.name),
+            reverse=True,
+        )
+        return candidates[0]
+
+    @staticmethod
+    def _cpython_destination(member_name: str, sysroot: Path) -> Path | None:
+        """Map a safe CPython archive member to its runtime destination."""
+        member_path = PurePosixPath(member_name.replace("\\", "/"))
+        if member_path.is_absolute() or ".." in member_path.parts:
+            return None
+        parts = member_path.parts
+
+        for index in range(len(parts) - 1):
+            if parts[index] == "bin" and parts[index + 1] in (
+                "python.elf",
+                "python3.12",
+            ):
+                if index + 2 == len(parts):
+                    return sysroot / "bin" / "python3.12"
+
+        for index in range(len(parts) - 1):
+            if parts[index : index + 2] == ("lib", "python3.12"):
+                relative = Path(*parts[index:])
+                destination = (sysroot / relative).resolve()
+                if destination.is_relative_to(sysroot.resolve()):
+                    return destination
+        return None
+
+    def _extract_cpython_tar(self, artifact: Path, sysroot: Path) -> None:
+        """Safely extract CPython runtime files from a tar archive."""
+        with tarfile.open(artifact, "r:*") as archive:
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                destination = self._cpython_destination(member.name, sysroot)
+                if destination is None:
+                    continue
+                source = archive.extractfile(member)
+                if source is None:
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with source, destination.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+                destination.chmod(member.mode & 0o777)
+
+    def _extract_cpython_zip(self, artifact: Path, sysroot: Path) -> None:
+        """Safely extract CPython runtime files from a zip archive."""
+        with zipfile.ZipFile(artifact) as archive:
+            for member in archive.infolist():
+                if member.is_dir():
+                    continue
+                destination = self._cpython_destination(member.filename, sysroot)
+                if destination is None:
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(member) as source, destination.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+                mode = (member.external_attr >> 16) & 0o777
+                if mode:
+                    destination.chmod(mode)
+
+    def _install_cpython(self, sysroot: Path, dependency: Dependency) -> None:
+        """Extract the base-setup CPython artifact into the runtime sysroot."""
+        version = str(dependency.ref.value)
 
         sentinel = sysroot / ".cpython-installed"
-        if sentinel.is_file() and sentinel.read_text().strip() == version_specifier:
+        python = sysroot / "bin" / "python3.12"
+        stdlib = sysroot / "lib" / "python3.12"
+        if (
+            sentinel.is_file()
+            and sentinel.read_text().strip() == version
+            and python.is_file()
+            and (stdlib / "os.py").is_file()
+        ):
+            self._remove_stdlib_build_artifacts(stdlib)
             log.info("CPython already installed, skipping")
             return
 
-        log.info(f"downloading pre-built CPython ({asset_name})")
+        artifact = self._cached_cpython_artifact(dependency)
+        log.info(f"extracting CPython from cached {artifact.name}")
+        python.unlink(missing_ok=True)
+        if stdlib.is_dir():
+            shutil.rmtree(stdlib)
+        if zipfile.is_zipfile(artifact):
+            self._extract_cpython_zip(artifact, sysroot)
+        else:
+            self._extract_cpython_tar(artifact, sysroot)
 
-        release = resolve_release(
-            repo="nanvix/cpython",
-            version_specifier=version_specifier,
-            gh_token=self.config.get("GH_TOKEN"),
-        )
+        missing = [
+            str(path.relative_to(sysroot))
+            for path in (python, stdlib / "os.py", stdlib / "site.py")
+            if not path.is_file()
+        ]
+        if missing:
+            log.fatal(
+                "CPython artifact is missing runtime files: " + ", ".join(missing),
+                code=EXIT_MISSING_DEP,
+            )
 
-        asset_path = download_release_asset(
-            repo="nanvix/cpython",
-            version_specifier=version_specifier,
-            asset_name=asset_name,
-            dest=cache_dir,
-            gh_token=self.config.get("GH_TOKEN"),
-            _release=release,
-        )
-
-        log.info("extracting CPython into sysroot")
-        with tarfile.open(asset_path, "r:*") as tf:
-            for member in tf.getmembers():
-                if not member.isfile():
-                    continue
-
-                # Tolerate both the legacy layout (entries rooted under
-                # ``sysroot/``) and the post-nanvix/cpython#742 layout
-                # where the ``sysroot/`` prefix has been dropped.
-                name = member.name.removeprefix("sysroot/")
-
-                # bin/python.elf → sysroot/bin/python3.12
-                if name == "bin/python.elf":
-                    member.name = "bin/python3.12"
-                    tf.extract(member, path=sysroot, filter="data")
-                # lib/python3.12/* → sysroot/lib/python3.12/*
-                elif name.startswith("lib/python3.12/"):
-                    member.name = name
-                    tf.extract(member, path=sysroot, filter="data")
-
-        sentinel.write_text(version_specifier)
+        self._remove_stdlib_build_artifacts(stdlib)
+        sentinel.write_text(version)
         log.success("CPython installed into sysroot")
+
+    @staticmethod
+    def _remove_stdlib_build_artifacts(stdlib: Path) -> None:
+        """Remove SDK build inputs that are not part of the Python runtime."""
+        for pattern in ("*.a", "*.c", "*.cpp", "*.h", "*.pxd", "*.pyx"):
+            for path in stdlib.rglob(pattern):
+                path.unlink(missing_ok=True)

--- a/.nanvix/src/test.py
+++ b/.nanvix/src/test.py
@@ -9,7 +9,6 @@ import os
 import re
 import shutil
 import subprocess
-import tempfile
 import time
 from pathlib import Path
 
@@ -115,7 +114,7 @@ class TestMixin(LibMixin):
     def _run_smoke_test(self, sysroot: Path) -> None:
         """Run the layer-2 smoke test."""
         log.info("=== smoke test ===")
-        tmp = Path(tempfile.gettempdir())
+        tmp = self._log_directory()
         log_file = tmp / "smoke.log"
         self._nanvix_run(sysroot, "smoke_test_l2.py", log_file)
 
@@ -253,7 +252,7 @@ class TestMixin(LibMixin):
         vmem.unlink(missing_ok=True)
         cbor.unlink(missing_ok=True)
 
-        tmp = Path(tempfile.gettempdir())
+        tmp = self._log_directory()
 
         # --- Phase 1: cold boot to generate snapshot ---------------------
         # nanvixd writes the snapshot files (kernel.vmem + kernel.whp.cbor)
@@ -310,7 +309,7 @@ class TestMixin(LibMixin):
 
         # --- Phase 2: warm restore to run hello-world --------------------
         log.info("snapshot smoke test: warm-restoring to run hello-world")
-        mount_dir = Path(tempfile.mkdtemp(prefix="nanvix-snap-smoke-"))
+        mount_dir = self._temporary_directory("nanvix-snap-smoke-")
         (mount_dir / "bootstrap.py").write_text('print("hello")\n')
         run_log = tmp / "snapshot-run.log"
         run_cmd = [
@@ -363,26 +362,12 @@ class TestMixin(LibMixin):
         test_end = int(os.environ.get("TEST_END", "999"))
         excluded: set[str] = set(exclude_tests.split()) if exclude_tests else set()
 
-        # Precompile stdlib and tests
-        host_python = self._host_python()
-        if host_python:
-            subprocess.run(
-                [
-                    host_python,
-                    "-m",
-                    "compileall",
-                    "-q",
-                    str(sysroot / "lib" / "python3.12"),
-                ],
-                capture_output=True,
-            )
-            for t in sysroot.glob("test_*.py"):
-                subprocess.run(
-                    [host_python, "-m", "py_compile", str(t)],
-                    capture_output=True,
-                )
+        # Standalone tests consume the bytecode-only ramfs produced by build.
+        # Other modes need an opt-0 cache beside the source tree.
+        if self.config.deployment_mode != "standalone":
+            self._precompile_pyc(sysroot, legacy=False, strip_sources=False)
 
-        tmp = Path(tempfile.gettempdir())
+        tmp = self._log_directory()
         total_pass = 0
         total_fail = 0
         total_skip = 0

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ auto-bootstraps [nanvix-zutil](https://github.com/nanvix/zutils).
 ### Prerequisites
 
 - **Python 3.12+** on the host
-- **Docker** (for cross-compilation and `.pyc` pre-compilation)
+- **Docker** (for SDK-hosted Python 3.12 bytecode generation)
 - **KVM** (`/dev/kvm`) on Linux for running Nanvix guests
 
 ### Build, Test, and Release
@@ -144,7 +144,9 @@ auto-bootstraps [nanvix-zutil](https://github.com/nanvix/zutils).
 git clone https://github.com/nanvix/nanvix-python.git
 cd nanvix-python
 
-./z setup      # Download Nanvix sysroot and pre-built CPython
+# Download the runtime-only sysroot and SDK-built CPython.
+./z setup --with-docker \
+  ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
 ./z build      # Install pip packages and generate ramfs image
 ./z test       # Run smoke test and functional tests
 ./z release    # Package standalone runtime bundle into dist/

--- a/doc/building.md
+++ b/doc/building.md
@@ -1,19 +1,18 @@
 # Building from Source
 
-This guide covers building the Nanvix Python runtime from source, including cross-compiling
-CPython 3.12 with pure Python pip packages.
+This guide covers assembling the Nanvix Python runtime from the SDK-built
+CPython 3.12 release and pure Python pip packages.
 
 ## Prerequisites
 
-| Requirement            | Notes                                                           |
-| ---------------------- | --------------------------------------------------------------- |
-| **Linux x86-64 host**  | Build scripts assume a Linux environment (or Docker on Windows) |
-| **Nanvix toolchain**   | `ghcr.io/nanvix/toolchain-python:latest` Docker image or `/opt/nanvix` |
-| **Python 3.12+**       | Host Python for nanvix-zutil and build orchestration            |
-| **nanvix-zutil**       | Auto-bootstrapped by `./z` wrapper scripts                     |
-| **Docker** (optional)  | Used automatically when a native toolchain is not available     |
-| **KVM** (`/dev/kvm`)   | Required to run Nanvix guests during testing                    |
-| **git**                | Submodule management                                            |
+| Requirement            | Notes                                                               |
+| ---------------------- | ------------------------------------------------------------------- |
+| **Linux x86-64 host**  | Full build/test support; Windows 11 uses the PowerShell flow         |
+| **Nanvix SDK**         | Pinned `nanvix-sdk-c-clang` image shown below                        |
+| **Python 3.12+**       | Host Python for nanvix-zutil and build orchestration                |
+| **nanvix-zutil**       | Auto-bootstrapped by `./z` wrapper scripts                          |
+| **Docker**             | Runs SDK host Python 3.12 for deterministic bytecode generation     |
+| **KVM** (`/dev/kvm`)   | Required to run Nanvix guests during Linux testing                  |
 
 ## Commands
 
@@ -21,8 +20,8 @@ All interaction is through the `./z` build script:
 
 | Command       | Description                                                                                                                                                  |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `./z setup`   | Download the Nanvix sysroot and build dependencies via nanvix-zutil and initialise git submodules.                                                           |
-| `./z build`   | Cross-compile CPython 3.12 with built-in modules and install pure Python packages into the sysroot.                                                          |
+| `./z setup`   | Download the Nanvix 0.20.0 runtime-only sysroot and exact SDK-built CPython 3.12.3 dependency.                                                               |
+| `./z build`   | Install pure Python packages and generate Python 3.12 bytecode and the standalone ramfs.                                                                      |
 | `./z test`    | Install pip site-packages, run the smoke test (built-in modules), then run functional tests on `nanvixd.elf`.                                                |
 | `./z release` | Package the sysroot into a standalone runtime tarball under `./dist/`.                                                                                       |
 | `./z clean`   | Remove all build artifacts, the sysroot, work directory, and release assets.                                                                                 |
@@ -34,10 +33,11 @@ All interaction is through the `./z` build script:
 git clone --recurse-submodules https://github.com/nanvix/nanvix-python.git
 cd nanvix-python
 
-# 2. Download the Nanvix runtime, init submodules, fetch build deps
-./z setup
+# 2. Download the runtime and exact SDK-built CPython dependency
+./z setup --with-docker \
+  ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
 
-# 3. Cross-compile CPython with built-in modules
+# 3. Install packages and generate the bytecode-only ramfs
 ./z build
 
 # 4. Install pip packages and run all tests
@@ -52,33 +52,22 @@ cd nanvix-python
 On Windows, use the PowerShell wrapper:
 
 ```powershell
-.\z.ps1 setup
-.\z.ps1 build   # requires Docker
-.\z.ps1 test    # requires Docker + KVM
-```
-
-### Selecting a Platform
-
-Set `NANVIX_MACHINE` and `NANVIX_DEPLOYMENT_MODE` before running:
-
-```bash
-export NANVIX_MACHINE=microvm
-export NANVIX_DEPLOYMENT_MODE=single-process
-./z setup && ./z build && ./z test
+.\z.ps1 setup --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
+.\z.ps1 build
+.\z.ps1 test
 ```
 
 ## Environment Variables
 
-| Variable                  | Default            | Description                                        |
-| ------------------------- | ------------------ | -------------------------------------------------- |
-| `NANVIX_MACHINE`          | `hyperlight`       | Target platform (`hyperlight` or `microvm`)        |
-| `NANVIX_DEPLOYMENT_MODE`  | `multi-process`    | Process mode (`multi-process` or `single-process`) |
-| `NANVIX_MEMORY_SIZE`      | `128mb`            | Memory size for the sysroot                        |
-| `NANVIX_TOOLCHAIN`        | `/opt/nanvix`      | Path to the Nanvix cross-compilation toolchain     |
-| `TEST_START`              | `1`                | First test number to run (inclusive)               |
-| `TEST_END`                | `999`              | Last test number to run (inclusive)                |
-| `TIMEOUT_SECONDS`         | `300`              | Per-test timeout in seconds                        |
-| `GH_TOKEN`                | —                  | GitHub token for authenticated API calls (CI)      |
+| Variable                  | Default      | Description                                   |
+| ------------------------- | ------------ | --------------------------------------------- |
+| `NANVIX_MACHINE`          | `microvm`    | Runtime platform (only `microvm` is supported) |
+| `NANVIX_DEPLOYMENT_MODE`  | `standalone` | Runtime mode (only `standalone` is supported) |
+| `NANVIX_MEMORY_SIZE`      | `256mb`      | Runtime memory size                           |
+| `TEST_START`              | `1`          | First test number to run (inclusive)          |
+| `TEST_END`                | `999`        | Last test number to run (inclusive)           |
+| `TIMEOUT_SECONDS`         | `300`        | Per-test timeout in seconds                   |
+| `GH_TOKEN`                | —            | GitHub token for authenticated API calls      |
 
 ## Project Layout
 
@@ -90,9 +79,6 @@ nanvix-python/
 ├── .nanvix/
 │   ├── nanvix.toml          # Package manifest (name, version, dependencies)
 │   └── z.py                 # Build script (ZScript subclass)
-├── deps/                    # Git submodules
-│   ├── cpython/             # CPython 3.12.3 (Nanvix fork)
-│   └── libexpat/            # libexpat 2.6.4
 ├── patches/                 # Build documentation
 ├── requirements/            # Pip package lists (base + extra)
 ├── tests/

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -10,21 +10,21 @@ workflow, following the same pattern used by all `usr/` packages.
 
 1. **Get Nanvix Info** — resolves sysroot metadata via `nanvix-zutil resolve`.
 2. **Build** (matrix) — runs `./z setup` → `./z build` → `./z test` → `./z release`
-   for each platform/process-mode combination.
+   for microvm standalone at 256 MB.
 3. **Release** — collects build artifacts, generates a lockfile, and creates
    a GitHub release tagged `{version}-nanvix-{nanvix_version}`.
 4. **Report Failure** — opens a GitHub issue on scheduled-run failures.
 
 ## Platform Matrix
 
-The CI matrix tests every combination of platform and process mode:
+The runtime release matrix contains one supported configuration:
 
-| Platform     | Process Mode     | Status       |
-| ------------ | ---------------- | ------------ |
-| `hyperlight` | `multi-process`  | Tested in CI |
-| `hyperlight` | `single-process` | Tested in CI |
-| `microvm`    | `multi-process`  | Tested in CI |
-| `microvm`    | `single-process` | Tested in CI |
+| Platform  | Process Mode | Memory | Status       |
+| --------- | ------------ | ------ | ------------ |
+| `microvm` | `standalone` | 256 MB | Tested in CI |
+
+Linux builds bytecode with the content-addressed `nanvix-sdk-c-clang` image.
+Windows tests consume the resulting bytecode-only ramfs.
 
 ## Triggers
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -3,16 +3,13 @@
 Contributions are welcome! To get started:
 
 1. Fork the repository and create a feature branch.
-2. Run `./z setup && ./z build && ./z test` to verify your changes
-   locally.
-3. If adding a new statically linked C extension, add a documentation
-   file in `patches/` following the existing `*_static_builtin.md`
-   pattern.
-4. If adding a new pip package, append it to the appropriate
+2. Run the SDK setup command from [building.md](building.md), then
+   `./z build && ./z test` to verify your changes locally.
+3. If adding a new pip package, append it to the appropriate
    requirements file and create a matching
    `tests/func/test_NNN_<package>.py` test file.
-5. Open a pull request — CI will automatically build and test all four
-   platform configurations.
+4. Open a pull request — CI builds and tests microvm standalone at 256 MB
+   on Linux and Windows.
 
 ## Further Reading
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -36,15 +36,17 @@ that can run Python scripts on any Linux host with KVM support.
 ./z release
 ```
 
-This writes artifacts to `./release-assets/` (override with
-`RELEASE_DIR`).
+This writes Linux `.tar.gz` and Windows `.zip` artifacts to `./dist/`.
 
 ## Bundle Contents
 
 ```text
-<platform>-<mode>/
-  bin/              # nanvixd.elf, kernel.elf, linuxd.elf, uservm.elf, python3.12
-  lib/              # Python standard library, site-packages, user.ld
+microvm-standalone-256mb/
+  bin/              # nanvixd host binary, kernel.elf, python3.12
+  lib/              # Python standard library and site-packages
+  mnt/              # User workloads
+  nanvix_rootfs.img # Bytecode-only Python stdlib and site-packages
+  python3.initrd    # Daemons and CPython interpreter
   README.md         # Usage instructions
 ```
 
@@ -56,12 +58,12 @@ to avoid runtime file-creation issues
 ## Running from a Bundle
 
 ```bash
-tar -xjf release-assets/hyperlight-multi-process.tar.bz2
-cd hyperlight-multi-process
+tar -xzf dist/microvm-standalone-256mb.tar.gz
+cd microvm-standalone-256mb
 
-# Run a script
-echo 'import numpy; print(numpy.__version__)' > test.py
-./bin/nanvixd.elf -- ./bin/python3.12 test.py
+# Run a script through the cold-start path
+echo 'print("Hello from Nanvix!")' > mnt/bootstrap.py
+./bin/nanvixd.elf -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd
 ```
 
 > **Note:** The `-c` flag only works with code that contains no spaces

--- a/scripts/get-nanvix-python.sh
+++ b/scripts/get-nanvix-python.sh
@@ -356,10 +356,10 @@ main() {
     echo ""
     info "Quick start:"
     info "  cd $output_dir"
-    info "  tar -xjf hyperlight-multi-process.tar.bz2"
-    info "  cd hyperlight-multi-process"
-    info "  echo \"print('Hello from Nanvix!')\" > hello.py"
-    info "  ./bin/nanvixd.elf -- ./bin/python3.12 hello.py"
+    info "  tar -xzf microvm-standalone-256mb.tar.gz"
+    info "  cd microvm-standalone-256mb"
+    info "  echo \"print('Hello from Nanvix!')\" > mnt/bootstrap.py"
+    info "  ./bin/nanvixd.elf -ramfs nanvix_rootfs.img -mount ./mnt -- python3.initrd"
 }
 
 # Run main function.


### PR DESCRIPTION
## Summary
- consume the exact SDK-built CPython 3.12.3 release resolved by zutils
- use the verified Nanvix SDK digest and its host Python 3.12 for deterministic bytecode
- keep downloaded Nanvix artifacts runtime-only and remove runtime linker-script assumptions
- preserve bytecode-only ramfs, cold/warm start, Linux/Windows release, and package flows
- target Nanvix v0.20.0 microvm standalone at 256mb

## Local validation
- clean setup/build with exact CPython dependency
- 113 functional tests and final smoke test
- benchmark
- SDK bytecode magic and ramfs policy checks
- Python formatting and strict type checks
- shell checks
- release tar/zip and Windows CPython bundle validation