### PR TITLE
[sdk] F: Use required build image type

### DIFF
--- a/.nanvix/src/build.py
+++ b/.nanvix/src/build.py
@@ -418,11 +418,6 @@ class BuildMixin(LibMixin):
         in_bytes = in_buf.getvalue()
 
         sdk_image = self.manifest.toolchain.effective_build_ref
-        if sdk_image is None:
-            log.fatal(
-                "nanvix.toml does not define an SDK build image.",
-                code=EXIT_BUILD_FAILURE,
-            )
 
         cmd = [
             "docker",


### PR DESCRIPTION
Remove the unreachable optional SDK image guard under zutils v0.16.1. Pyright and Black pass.